### PR TITLE
Optimize sample

### DIFF
--- a/gllm/layers/sampler.py
+++ b/gllm/layers/sampler.py
@@ -26,29 +26,31 @@ class Sampler:
         p: torch.Tensor,
         k: torch.Tensor,
     ) -> torch.Tensor:
-        logits_sort, logits_idx = logits.sort(dim=-1, descending=False)
+        # Use topk instead of full sort for better performance.
+        # Determine the maximum k value needed across the batch.
+        k_long = k.to(torch.long)
+        max_k = min(k_long.max().item(), logits.size(1))
 
-        # Apply top-k.
-        top_k_mask = logits_sort.size(1) - k.to(torch.long)
-        # Get all the top_k values.
-        top_k_mask = logits_sort.gather(1, top_k_mask.unsqueeze(dim=1))
-        top_k_mask = logits_sort < top_k_mask
-        logits_sort.masked_fill_(top_k_mask, -float("inf"))
+        # Get top-k values and indices (descending order).
+        top_values, top_indices = torch.topk(logits, max_k, dim=-1, sorted=True)
 
-        # Apply top-p.
-        probs_sort = logits_sort.softmax(dim=-1)
-        probs_sum = probs_sort.cumsum(dim=-1)
-        top_p_mask = probs_sum <= 1 - p.unsqueeze(dim=1)
-        # at least one
-        top_p_mask[:, -1] = False
-        logits_sort.masked_fill_(top_p_mask, -float("inf"))
+        # Apply per-sample top-k masking (for samples with k < max_k).
+        if not (k_long == max_k).all():
+            # Create a range tensor [0, 1, ..., max_k-1] and mask positions >= per-sample k
+            range_tensor = torch.arange(max_k, device=logits.device).unsqueeze(0)
+            topk_mask = range_tensor >= k_long.unsqueeze(1)
+            top_values.masked_fill_(topk_mask, -float("inf"))
 
-        # Re-sort the probabilities.
-        src = torch.arange(logits_idx.shape[-1], device=logits_idx.device).expand_as(
-            logits_idx
-        )
-        logits_idx_inv = torch.empty_like(logits_idx).scatter_(
-            dim=-1, index=logits_idx, src=src
-        )
-        logits = torch.gather(logits_sort, dim=-1, index=logits_idx_inv)
+        # Apply top-p filtering on the top-k values.
+        probs_sort = torch.softmax(top_values, dim=-1)
+        probs_cumsum = probs_sort.cumsum(dim=-1)
+        # Remove tokens with cumulative probability above the threshold,
+        # but always keep at least one token (the top-1).
+        top_p_mask = (probs_cumsum - probs_sort) >= p.unsqueeze(dim=1)
+        top_values.masked_fill_(top_p_mask, -float("inf"))
+
+        # Scatter filtered values back to original logit positions.
+        # Fill with -inf first, then place the filtered top-k values.
+        logits.fill_(-float("inf"))
+        logits.scatter_(dim=-1, index=top_indices, src=top_values)
         return logits


### PR DESCRIPTION
This PR optimizes TPOT.

- Before this PR

```
============ Serving Benchmark Result ============
Backend:                                 vllm-chat 
Traffic request rate:                    inf       
Max request concurrency:                 32        
Successful requests:                     3000      
Benchmark duration (s):                  44.31     
Total input tokens:                      195373    
Total input text tokens:                 195373    
Total generated tokens:                  97272     
Total generated tokens (retokenized):    96946     
Request throughput (req/s):              67.71     
Input token throughput (tok/s):          4409.27   
Output token throughput (tok/s):         2195.28   
Peak output token throughput (tok/s):    2497.00   
Peak concurrent requests:                109       
Total token throughput (tok/s):          6604.55   
Concurrency:                             31.83     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   470.09    
Median E2E Latency (ms):                 469.99    
P90 E2E Latency (ms):                    819.27    
P99 E2E Latency (ms):                    936.55    
---------------Time to First Token----------------
Mean TTFT (ms):                          39.35     
Median TTFT (ms):                        38.23     
P99 TTFT (ms):                           164.44    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          13.71     
Median TPOT (ms):                        13.70     
P99 TPOT (ms):                           19.60     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           13.73     
Median ITL (ms):                         17.70     
P95 ITL (ms):                            22.82     
P99 ITL (ms):                            28.01     
Max ITL (ms):                            185.12    
==================================================
```

- After this PR

```
============ Serving Benchmark Result ============
Backend:                                 vllm-chat 
Traffic request rate:                    inf       
Max request concurrency:                 32        
Successful requests:                     3000      
Benchmark duration (s):                  38.23     
Total input tokens:                      195373    
Total input text tokens:                 195373    
Total generated tokens:                  97272     
Total generated tokens (retokenized):    96955     
Request throughput (req/s):              78.47     
Input token throughput (tok/s):          5110.60   
Output token throughput (tok/s):         2544.46   
Peak output token throughput (tok/s):    2880.00   
Peak concurrent requests:                125       
Total token throughput (tok/s):          7655.05   
Concurrency:                             31.81     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   405.32    
Median E2E Latency (ms):                 407.11    
P90 E2E Latency (ms):                    706.12    
P99 E2E Latency (ms):                    814.23    
---------------Time to First Token----------------
Mean TTFT (ms):                          36.31     
Median TTFT (ms):                        33.06     
P99 TTFT (ms):                           169.48    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          11.79     
Median TPOT (ms):                        11.74     
P99 TPOT (ms):                           18.09     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           11.77     
Median ITL (ms):                         14.74     
P95 ITL (ms):                            21.56     
P99 ITL (ms):                            27.31     
Max ITL (ms):                            185.65    
==================================================
```

### Qwen2.5-VL-3B-Instruct

|                 Tasks                 |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|---------------------------------------|------:|------|-----:|------|---|-----:|---|-----:|
|mmmu_val                               |      0|none  |      |acc   |   |0.4622|±  |0.0163|