### PR TITLE
Refactor sampler

### DIFF
--- a/gllm/input_data.py
+++ b/gllm/input_data.py
@@ -66,19 +66,25 @@ class InputData:
                 seq.top_k if seq.top_k != -1 else self.memory_manager.vocab_size
                 for seq in self.seqs
             ],
-            self.memory_manager.dtype,
+            torch.int32,
             "cuda",
             True,
         )
-        repetition_penalty = async_tensor_h2d(
-            [seq.repetition_penalty for seq in self.seqs],
-            self.memory_manager.dtype,
-            "cuda",
-            True,
+        self.needs_repetition_penalty = any(
+            seq.repetition_penalty != 1.0 for seq in self.seqs
         )
-        self.repetition_penalty = repetition_penalty.unsqueeze(dim=1).repeat(
-            1, self.memory_manager.vocab_size
-        )
+        if self.needs_repetition_penalty:
+            repetition_penalty = async_tensor_h2d(
+                [seq.repetition_penalty for seq in self.seqs],
+                self.memory_manager.dtype,
+                "cuda",
+                True,
+            )
+            self.repetition_penalty = repetition_penalty.unsqueeze(dim=1).repeat(
+                1, self.memory_manager.vocab_size
+            )
+        else:
+            self.repetition_penalty = None
 
     def cal_input(self, seqs: List[Sequence]):
         assert len(seqs) != 0
@@ -149,6 +155,7 @@ class InputData:
             "top_p",
             "top_k",
             "repetition_penalty",
+            "needs_repetition_penalty",
         ]
         mla_attrs_copy = [
             "num_actual_tokens",

--- a/gllm/layers/sampler.py
+++ b/gllm/layers/sampler.py
@@ -1,56 +1,76 @@
 import torch
+from sgl_kernel import top_k_top_p_sampling_from_probs
 
 from gllm.input_data import InputData
 
 
+def _fused_top_k_top_p_sample(
+    probs: torch.Tensor,
+    top_ks: torch.Tensor,
+    top_ps: torch.Tensor,
+) -> torch.Tensor:
+    """Fused top-k / top-p sampling via sgl_kernel."""
+    return top_k_top_p_sampling_from_probs(
+        probs.float().contiguous(),
+        top_ks.to(torch.int32),
+        top_ps,
+        filter_apply_order="joint",
+    )
+
+
 class Sampler:
 
-    def forward(self, logits: torch.Tensor, input_data: InputData):
-        # repetition_penalty
-        logits /= torch.where(logits > 0, input_data.repetition_penalty, 1.0)
-        logits *= torch.where(logits <= 0, 1.0, input_data.repetition_penalty)
-        # temperature
-        logits.div_(input_data.temperature.unsqueeze_(dim=1))
-        # top_p top_k
-        logits = self._apply_top_k_top_p(logits, input_data.top_p, input_data.top_k)
-        probs = torch.softmax(logits, dim=1)
+    def forward(self, logits: torch.Tensor, input_data: InputData) -> list[int]:
+        flags = self._get_sampling_flags(input_data)
 
-        q = torch.empty_like(probs)
-        q.exponential_()
-        return probs.div_(q).argmax(dim=1).cpu().numpy().tolist()
-        # return torch.multinomial(probs, 1).squeeze(1).cpu().numpy().tolist()
+        if flags["need_repetition_penalty"]:
+            self._apply_repetition_penalty(logits, input_data)
 
-    def _apply_top_k_top_p(
-        self,
-        logits: torch.Tensor,
-        p: torch.Tensor,
-        k: torch.Tensor,
-    ) -> torch.Tensor:
-        # Use topk instead of full sort for better performance.
-        # Determine the maximum k value needed across the batch.
-        k_long = k.to(torch.long)
-        max_k = min(k_long.max().item(), logits.size(1))
+        if flags["is_all_greedy"]:
+            if flags["need_temperature"]:
+                logits.div_(input_data.temperature.unsqueeze(1))
+            return torch.argmax(logits, dim=-1).cpu().tolist()
 
-        # Get top-k values and indices (descending order).
-        top_values, top_indices = torch.topk(logits, max_k, dim=-1, sorted=True)
+        if flags["need_temperature"]:
+            logits.div_(input_data.temperature.unsqueeze(1))
 
-        # Apply per-sample top-k masking (for samples with k < max_k).
-        if not (k_long == max_k).all():
-            # Create a range tensor [0, 1, ..., max_k-1] and mask positions >= per-sample k
-            range_tensor = torch.arange(max_k, device=logits.device).unsqueeze(0)
-            topk_mask = range_tensor >= k_long.unsqueeze(1)
-            top_values.masked_fill_(topk_mask, -float("inf"))
+        simple_case = (
+            not flags["need_top_p_sampling"] and not flags["need_top_k_sampling"]
+        )
+        probs = torch.softmax(logits, dim=-1)
 
-        # Apply top-p filtering on the top-k values.
-        probs_sort = torch.softmax(top_values, dim=-1)
-        probs_cumsum = probs_sort.cumsum(dim=-1)
-        # Remove tokens with cumulative probability above the threshold,
-        # but always keep at least one token (the top-1).
-        top_p_mask = (probs_cumsum - probs_sort) >= p.unsqueeze(dim=1)
-        top_values.masked_fill_(top_p_mask, -float("inf"))
+        if simple_case:
+            batch_next_token_ids = torch.multinomial(probs, num_samples=1).view(-1)
+        else:
+            batch_next_token_ids = _fused_top_k_top_p_sample(
+                probs, input_data.top_k, input_data.top_p
+            )
 
-        # Scatter filtered values back to original logit positions.
-        # Fill with -inf first, then place the filtered top-k values.
-        logits.fill_(-float("inf"))
-        logits.scatter_(dim=-1, index=top_indices, src=top_values)
-        return logits
+        return batch_next_token_ids.cpu().tolist()
+
+    @staticmethod
+    def _get_sampling_flags(input_data: InputData) -> dict[str, bool]:
+        seqs = input_data.seqs
+        vocab_size = input_data.memory_manager.vocab_size
+        return {
+            "is_all_greedy": all(seq.top_k <= 1 for seq in seqs),
+            "need_top_p_sampling": any(seq.top_p < 1.0 for seq in seqs),
+            "need_top_k_sampling": any(
+                seq.top_k != -1 and seq.top_k < vocab_size for seq in seqs
+            ),
+            "need_repetition_penalty": getattr(
+                input_data, "needs_repetition_penalty", False
+            ),
+            "need_temperature": any(
+                seq.temperature > 1e-5 and abs(seq.temperature - 1.0) > 1e-5
+                for seq in seqs
+            ),
+        }
+
+    @staticmethod
+    def _apply_repetition_penalty(
+        logits: torch.Tensor, input_data: InputData
+    ) -> None:
+        penalty = input_data.repetition_penalty
+        logits.div_(torch.where(logits > 0, penalty, 1.0))
+        logits.mul_(torch.where(logits <= 0, 1.0, penalty))

--- a/gllm/layers/sampler.py
+++ b/gllm/layers/sampler.py
@@ -53,7 +53,7 @@ class Sampler:
         seqs = input_data.seqs
         vocab_size = input_data.memory_manager.vocab_size
         return {
-            "is_all_greedy": all(seq.top_k <= 1 for seq in seqs),
+            "is_all_greedy": all(seq.top_k == 1 for seq in seqs),
             "need_top_p_sampling": any(seq.top_p < 1.0 for seq in seqs),
             "need_top_k_sampling": any(
                 seq.top_k != -1 and seq.top_k < vocab_size for seq in seqs


### PR DESCRIPTION
- Before this PR
```
============ Serving Benchmark Result ============
Backend:                                 vllm      
Traffic request rate:                    inf       
Max request concurrency:                 32        
Successful requests:                     3000      
Benchmark duration (s):                  74.83     
Total input tokens:                      3072000   
Total input text tokens:                 3072000   
Total generated tokens:                  192000    
Total generated tokens (retokenized):    191836    
Request throughput (req/s):              40.09     
Input token throughput (tok/s):          41053.48  
Output token throughput (tok/s):         2565.84   
Peak output token throughput (tok/s):    2944.00   
Peak concurrent requests:                95        
Total token throughput (tok/s):          43619.32  
Concurrency:                             31.89     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   795.51    
Median E2E Latency (ms):                 793.82    
P90 E2E Latency (ms):                    808.05    
P99 E2E Latency (ms):                    890.13    
---------------Time to First Token----------------
Mean TTFT (ms):                          124.53    
Median TTFT (ms):                        143.36    
P99 TTFT (ms):                           248.89    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          10.65     
Median TPOT (ms):                        10.37     
P99 TPOT (ms):                           12.26     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           10.66     
Median ITL (ms):                         7.66      
P95 ITL (ms):                            24.20     
P99 ITL (ms):                            74.76     
Max ITL (ms):                            157.96    
==================================================
```

- After this PR
```
============ Serving Benchmark Result ============
Backend:                                 vllm      
Traffic request rate:                    inf       
Max request concurrency:                 32        
Successful requests:                     3000      
Benchmark duration (s):                  72.07     
Total input tokens:                      3072000   
Total input text tokens:                 3072000   
Total generated tokens:                  192000    
Total generated tokens (retokenized):    191837    
Request throughput (req/s):              41.62     
Input token throughput (tok/s):          42622.50  
Output token throughput (tok/s):         2663.91   
Peak output token throughput (tok/s):    3135.00   
Peak concurrent requests:                94        
Total token throughput (tok/s):          45286.40  
Concurrency:                             31.88     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   765.93    
Median E2E Latency (ms):                 762.89    
P90 E2E Latency (ms):                    782.58    
P99 E2E Latency (ms):                    871.58    
---------------Time to First Token----------------
Mean TTFT (ms):                          127.39    
Median TTFT (ms):                        143.11    
P99 TTFT (ms):                           276.98    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          10.14     
Median TPOT (ms):                        9.89      
P99 TPOT (ms):                           11.81     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           10.14     
Median ITL (ms):                         7.17      
P95 ITL (ms):                            18.38     
P99 ITL (ms):                            75.76     
Max ITL (ms):                            166.47    
==================================================
```

### Qwen3-0.6B

```
{'total': {'#correct': 414, '#wrong': 986, 'score': 29.57}, 'business': {'#correct': 40, '#wrong': 60}, 'law': {'#correct': 15, '#wrong': 85}, 'psychology': {'#correct': 32, '#wrong': 68}, 'biology': {'#correct': 29, '#wrong': 71}, 'chemistry': {'#correct': 27, '#wrong': 73}, 'history': {'#correct': 20, '#wrong': 80}, 'other': {'#correct': 23, '#wrong': 77}, 'health': {'#correct': 23, '#wrong': 77}, 'economics': {'#correct': 40, '#wrong': 60}, 'math': {'#correct': 58, '#wrong': 42}, 'physics': {'#correct': 34, '#wrong': 66}, 'computer science': {'#correct': 33, '#wrong': 67}, 'philosophy': {'#correct': 15, '#wrong': 85}, 'engineering': {'#correct': 25, '#wrong': 75}}
```