### PR TITLE
Opt vl

### DIFF
--- a/gllm/async_utils.py
+++ b/gllm/async_utils.py
@@ -8,7 +8,13 @@ import torch
 
 @dataclass
 class FutureIndices:
-    indices: torch.Tensor
+    # NOTE: ``indices`` is intentionally optional. Allocating a GPU tensor for
+    # the future slot ids forced a ``.cpu().tolist()`` on the calling stream,
+    # which inserted a hidden host-side sync on every batch. The slot ids are
+    # purely a CPU concept (used by the scheduler) and ``interval`` carries the
+    # information ``store_to_map`` and ``resolve_future`` actually need, so we
+    # avoid materializing the GPU tensor by default.
+    indices: Optional[torch.Tensor] = None
     interval: Optional[slice] = None
 
 
@@ -43,10 +49,9 @@ class FutureMap:
         self.future_ct = (cur + batch_size) % self.future_limit
         start = cur + 1
         end = cur + 1 + batch_size
-        indices = torch.arange(
-            start, end, dtype=torch.int64, device=self.device
-        )
-        return FutureIndices(indices=indices, interval=slice(start, end))
+        # ``store_to_map`` and ``resolve_future`` only need ``interval``;
+        # ``indices`` is lazily materialized on the rare paths that want it.
+        return FutureIndices(indices=None, interval=slice(start, end))
 
     def resolve_future(self, input_ids: torch.Tensor) -> None:
         input_ids[:] = torch.where(

--- a/gllm/input_data.py
+++ b/gllm/input_data.py
@@ -139,44 +139,56 @@ class InputData:
         self.cal_input(seqs)
         self.copy_to_input_buffer()
 
-    def set_input_from_prebuilt(self, input_data):
-        common_attrs_copy = [
-            "seqs",
-            "tokens_cpu",
-            "positions_cpu",
-            "mrope_positions_cpu",
-            "slot_mapping_cpu",
-            "block_table_cpu",
-            "max_seq_len",
-            "seq_lens_cpu",
-            "max_query_len",
-            "query_start_loc_cpu",
-            "temperature",
-            "top_p",
-            "top_k",
-            "repetition_penalty",
-            "needs_repetition_penalty",
-        ]
-        mla_attrs_copy = [
-            "num_actual_tokens",
-            "num_decodes",
-            "num_decode_tokens",
-            "num_prefills",
-            "max_context_len",
-            "decode_seq_lens_cpu",
-            "prefill_max_query_len",
-            "prefill_query_start_loc_cpu",
-            "chunk_starts_cpu",
-            "chunk_seq_lens_cpu",
-            "cu_seq_lens_cpu",
-        ]
-        for attr in common_attrs_copy:
+    # Attributes copied verbatim from a prebuilt InputData.
+    _PREBUILT_COMMON_ATTRS = (
+        "seqs",
+        "tokens_cpu",
+        "positions_cpu",
+        "mrope_positions_cpu",
+        "slot_mapping_cpu",
+        "block_table_cpu",
+        "max_seq_len",
+        "seq_lens_cpu",
+        "max_query_len",
+        "query_start_loc_cpu",
+        "temperature",
+        "top_p",
+        "top_k",
+        "repetition_penalty",
+        "needs_repetition_penalty",
+    )
+    _PREBUILT_MLA_ATTRS = (
+        "num_actual_tokens",
+        "num_decodes",
+        "num_decode_tokens",
+        "num_prefills",
+        "max_context_len",
+        "decode_seq_lens_cpu",
+        "prefill_max_query_len",
+        "prefill_query_start_loc_cpu",
+        "chunk_starts_cpu",
+        "chunk_seq_lens_cpu",
+        "cu_seq_lens_cpu",
+    )
+
+    def set_input_from_prebuilt_cpu(self, input_data):
+        """CPU-only portion of ``set_input_from_prebuilt``.
+
+        Copies the prebuilt CPU attributes onto ``self`` without touching the
+        shared GPU input buffers. Callers that want to overlap CPU prep with
+        an in-flight GPU forward should pair this with a later
+        :meth:`copy_to_input_buffer` call once the previous forward has
+        released the input buffers (see ``OverlapModelRunner``).
+        """
+        for attr in self._PREBUILT_COMMON_ATTRS:
             setattr(self, attr, getattr(input_data, attr, None))
 
         if self.use_mla:
-            for attr in mla_attrs_copy:
+            for attr in self._PREBUILT_MLA_ATTRS:
                 setattr(self, attr, getattr(input_data, attr, None))
 
+    def set_input_from_prebuilt(self, input_data):
+        self.set_input_from_prebuilt_cpu(input_data)
         self.copy_to_input_buffer()
 
     def _cal_tokens(self, seqs: List[Sequence]):

--- a/gllm/model_runner.py
+++ b/gllm/model_runner.py
@@ -250,99 +250,200 @@ class ModelRunner:
         return mm_contents if len(mm_contents["image"]) + len(mm_contents["video"]) != 0 else None
 
     @torch.inference_mode()
-    def mm_prepare_inputs(self, seqs: List[Sequence]):
-        # Calculate the embedding (on cuda) and positions (on cpu) of pic
-        batch_embeddings = []
-        batch_positions = []
+    def _mm_prepare_cpu(self, seqs: List[Sequence]) -> Dict:
+        """CPU phase of :meth:`mm_prepare_inputs`.
+
+        Computes mrope positions and collects per-seq prefill work to run in
+        :meth:`_mm_prepare_gpu`. Decode seqs (``seq.computed_prompt``) only
+        contribute positions and a token count: their embedding rows are
+        re-written in one fused call by
+        :meth:`OverlapModelRunner._fixup_vl_decode_embeddings` on the forward
+        stream, so we skip the per-seq ``embed_input_ids`` launch (and the
+        attendant ``aten::any`` / ``aten::clamp`` sync points) entirely.
+
+        Returning a context dict (instead of going straight to GPU work) lets
+        the overlap scheduler run this phase concurrently with the previous
+        batch's GPU forward.
+        """
+        batch_positions: List[torch.Tensor] = []
+        prefill_works: List[Dict] = []
+        num_decode_tokens = 0
+        in_decode = True
+
         for seq in seqs:
-            embedding = None
-            position = None
             if seq.computed_prompt:
+                # Decode token: positions only; embed is deferred to fixup.
+                # The scheduler places decode seqs before prefill seqs, so
+                # the contiguous decode block always sits at the front.
+                assert in_decode, (
+                    "scheduler invariant violated: decode seqs must precede "
+                    "prefill seqs within a batch"
+                )
                 embedding_info = self.embedding_cache[seq.seq_id]
-                to_compute = torch.tensor(seq.to_compute_tokens)
-                if (to_compute < 0).any():
-                    to_compute = to_compute.clamp(min=0)
-                embedding = self.model.embed_input_ids(to_compute)
                 position = MRotaryEmbedding.get_next_input_positions(
                     embedding_info.mrope_position_delta,
                     seq.computed_token_num,
                     seq.seq_len,
                 )
-                position = torch.tensor(position, device="cpu")
+                batch_positions.append(torch.tensor(position, device="cpu"))
+                num_decode_tokens += seq.to_compute_token_num
+                continue
+
+            in_decode = False
+            if seq.seq_id not in self.embedding_cache:
+                mm_input: Dict = {}
+                image_grid_thw: torch.Tensor = None
+                video_grid_thw: torch.Tensor = None
+                if seq.mm_contents is not None:
+                    if len(seq.mm_contents["image"]) != 0:
+                        images = load_images(seq.mm_contents["image"])
+                        images_input = self.image_processor(images=images)
+                        mm_input.update(images_input)
+                        image_grid_thw = images_input["image_grid_thw"]
+                    if len(seq.mm_contents["video"]) != 0:
+                        videos = []
+                        video_metadata = []
+                        for video_content in seq.mm_contents["video"]:
+                            video_data, metadata = load_video(video_content)
+                            videos.append(video_data)
+                            video_metadata.append(metadata)
+                        videos_input = self.video_processor(
+                            videos=videos,
+                            video_metadata=video_metadata,
+                        )
+                        mm_input.update(videos_input)
+                        video_grid_thw = videos_input["video_grid_thw"]
+
+                input_ids_cpu = torch.tensor(seq.token_ids)
+                placeholder_token_id = torch.tensor(
+                    self.model.get_mm_placeholder_token_ids()
+                )
+                is_multimodal = torch.isin(input_ids_cpu, placeholder_token_id)
+                prompt_positions, mrope_position_delta = (
+                    MRotaryEmbedding.get_input_positions(
+                        input_tokens=seq.token_ids,
+                        hf_config=self.model.config,
+                        image_grid_thw=image_grid_thw,
+                        video_grid_thw=video_grid_thw,
+                        second_per_grid_ts=None,
+                    )
+                )
+                batch_positions.append(
+                    prompt_positions[:, seq.computed_token_num : seq.seq_len]
+                )
+                prefill_works.append(
+                    {
+                        "kind": "uncached",
+                        "seq": seq,
+                        "input_ids": input_ids_cpu,
+                        "is_multimodal": is_multimodal,
+                        "mm_input": mm_input,
+                        "prompt_positions": prompt_positions,
+                        "mrope_position_delta": mrope_position_delta,
+                        "image_grid_thw": image_grid_thw,
+                        "video_grid_thw": video_grid_thw,
+                    }
+                )
             else:
-                embedding_info = None
-                if seq.seq_id not in self.embedding_cache:
-                    mm_embeddings = None
-                    image_grid_thw: torch.Tensor = None
-                    video_grid_thw: torch.Tensor = None
-                    if seq.mm_contents is not None:
-                        mm_input = {}
-                        if len(seq.mm_contents["image"]) != 0:
-                            images = load_images(seq.mm_contents["image"])
-                            images_input = self.image_processor(images=images)
-                            mm_input.update(images_input)
-                            image_grid_thw = images_input["image_grid_thw"]
-                        if len(seq.mm_contents["video"]) != 0:
-                            videos = []
-                            video_metadata = []
-                            for video_content in seq.mm_contents["video"]:
-                                video_data, metadata = load_video(video_content)
-                                videos.append(video_data)
-                                video_metadata.append(metadata)
-                            videos_input = self.video_processor(
-                                videos=videos,
-                                video_metadata=video_metadata,
-                            )
-                            mm_input.update(videos_input)
-                            video_grid_thw = videos_input["video_grid_thw"]
-                        mm_embeddings = self.model.embed_multimodal(
-                            **mm_input
-                        )
-                    
-                    input_ids = torch.tensor(seq.token_ids)
-                    placeholder_token_id = torch.tensor(self.model.get_mm_placeholder_token_ids())
-                    prompt_embeddings = self.model.embed_input_ids(
-                        input_ids, 
-                        mm_embeddings,
-                        torch.isin(input_ids, placeholder_token_id)
-                    )
-                    if image_grid_thw is not None:
-                        image_grid_thw = image_grid_thw.cpu()
-                    if video_grid_thw is not None:
-                        video_grid_thw = video_grid_thw.cpu()
-                    prompt_positions, mrope_position_delta = (
-                        MRotaryEmbedding.get_input_positions(
-                            input_tokens=seq.token_ids,
-                            hf_config=self.model.config,
-                            image_grid_thw=image_grid_thw,
-                            video_grid_thw=video_grid_thw,
-                            second_per_grid_ts=None,
-                        )
-                    )
-                    embedding_info = EmbeddingInfo(
-                        prompt_embeddings, prompt_positions, mrope_position_delta
-                    )
-                    self.embedding_cache[seq.seq_id] = embedding_info
-                    embedding = prompt_embeddings[
-                        seq.computed_token_num : seq.seq_len, :
-                    ]
-                    position = prompt_positions[:, seq.computed_token_num : seq.seq_len]
-                else:
-                    embedding_info = self.embedding_cache[seq.seq_id]
-                    embedding = embedding_info.embedding[
-                        seq.computed_token_num : seq.seq_len, :
-                    ]
-                    position = embedding_info.prompt_positions[
+                embedding_info = self.embedding_cache[seq.seq_id]
+                batch_positions.append(
+                    embedding_info.prompt_positions[
                         :, seq.computed_token_num : seq.seq_len
                     ]
-                if seq.seq_len == seq.prompt_len:
-                    # invalidate embedding_cache
-                    embedding_info.embedding = None
+                )
+                prefill_works.append(
+                    {
+                        "kind": "cached",
+                        "seq": seq,
+                        "embedding_info": embedding_info,
+                    }
+                )
+
+        mrope_positions = torch.concat(batch_positions, dim=1)
+        return {
+            "prefill_works": prefill_works,
+            "mrope_positions": mrope_positions,
+            "num_decode_tokens": num_decode_tokens,
+        }
+
+    @torch.inference_mode()
+    def _mm_prepare_gpu(self, ctx: Dict) -> Optional[torch.Tensor]:
+        """GPU phase of :meth:`mm_prepare_inputs`.
+
+        Runs each prefill seq's multimodal+text embed and produces a single
+        ``input_embeddings`` tensor laid out as ``[decode_rows, prefill_rows]``.
+        Decode rows are an uninitialized placeholder; they will be overwritten
+        by :meth:`OverlapModelRunner._fixup_vl_decode_embeddings` on the
+        forward stream right before the model runs, so the placeholder content
+        is irrelevant.
+        """
+        batch_embeddings: List[torch.Tensor] = []
+        for work in ctx["prefill_works"]:
+            seq = work["seq"]
+            if work["kind"] == "uncached":
+                mm_embeddings = None
+                mm_input = work["mm_input"]
+                if mm_input:
+                    mm_embeddings = self.model.embed_multimodal(**mm_input)
+                prompt_embeddings = self.model.embed_input_ids(
+                    work["input_ids"],
+                    mm_embeddings,
+                    work["is_multimodal"],
+                )
+
+                image_grid_thw = work["image_grid_thw"]
+                if image_grid_thw is not None:
+                    image_grid_thw = image_grid_thw.cpu()
+                video_grid_thw = work["video_grid_thw"]
+                if video_grid_thw is not None:
+                    video_grid_thw = video_grid_thw.cpu()
+
+                embedding_info = EmbeddingInfo(
+                    prompt_embeddings,
+                    work["prompt_positions"],
+                    work["mrope_position_delta"],
+                )
+                self.embedding_cache[seq.seq_id] = embedding_info
+                embedding = prompt_embeddings[
+                    seq.computed_token_num : seq.seq_len, :
+                ]
+            else:
+                embedding_info = work["embedding_info"]
+                embedding = embedding_info.embedding[
+                    seq.computed_token_num : seq.seq_len, :
+                ]
+
+            if seq.seq_len == seq.prompt_len:
+                # Prefill just finished; drop the cached embedding tensor to
+                # free memory. We still keep mrope_position_delta around for
+                # future decode-position calculations.
+                embedding_info.embedding = None
+
             batch_embeddings.append(embedding)
-            batch_positions.append(position)
-        input_embeddings = torch.concat(batch_embeddings)
-        positions = torch.concat(batch_positions, dim=1)
-        return input_embeddings, positions
+
+        num_decode_tokens = ctx["num_decode_tokens"]
+        if num_decode_tokens > 0:
+            # Placeholder rows; ``_fixup_vl_decode_embeddings`` re-embeds these
+            # token positions in a single fused launch on the forward stream
+            # after future-token resolution. ``empty`` is fine since the
+            # contents are dead-on-arrival.
+            placeholder = torch.empty(
+                (num_decode_tokens, self.hidden_size),
+                device=self.input_hidden_states.device,
+                dtype=self.input_hidden_states.dtype,
+            )
+            batch_embeddings.insert(0, placeholder)
+
+        if not batch_embeddings:
+            return None
+        return torch.concat(batch_embeddings)
+
+    @torch.inference_mode()
+    def mm_prepare_inputs(self, seqs: List[Sequence]):
+        """Single-shot wrapper kept for the non-overlap worker path."""
+        ctx = self._mm_prepare_cpu(seqs)
+        input_embeddings = self._mm_prepare_gpu(ctx)
+        return input_embeddings, ctx["mrope_positions"]
 
     def prepare_input_embeddings(self, hidden_states=None):
         if hidden_states is not None:
@@ -516,6 +617,9 @@ class OverlapModelRunner(ModelRunner):
             ),
         ]
         self._next_tokens_buf_idx = 0
+        # Holds the context produced by ``_mm_prepare_cpu`` between the CPU
+        # and GPU phases of input prep when the overlap worker drives us.
+        self._pending_mm_ctx: Optional[Dict] = None
         logger.info(
             "Overlap scheduling enabled: future_limit=%s tp_size=%s",
             self.future_map.future_limit,
@@ -524,6 +628,41 @@ class OverlapModelRunner(ModelRunner):
 
     def sync_before_next_prepare(self) -> None:
         self.overlap_runtime.input_consumed_event.synchronize()
+
+    def prepare_input_cpu(self, input_data: InputData) -> None:
+        """CPU-only portion of input prep.
+
+        Safe to invoke while the previous batch's forward is still consuming
+        the shared GPU input buffers. The pair :meth:`prepare_input_gpu` must
+        be called once :meth:`sync_before_next_prepare` has released those
+        buffers; only then is it sound to issue the H2D copies and write to
+        ``input_hidden_states``.
+        """
+        self.input_data.set_input_from_prebuilt_cpu(input_data)
+        if self.use_mm and is_first_pp_rank():
+            assert self._pending_mm_ctx is None, (
+                "prepare_input_cpu called twice without an intervening "
+                "prepare_input_gpu"
+            )
+            self._pending_mm_ctx = self._mm_prepare_cpu(self.input_data.seqs)
+        else:
+            self._pending_mm_ctx = None
+
+    def prepare_input_gpu(self) -> None:
+        """GPU/H2D portion of input prep.
+
+        Must run after :meth:`sync_before_next_prepare`. Performs the H2D
+        copies into the shared input buffers, runs the deferred multimodal
+        embedding work for any prefill seqs, and writes the merged embedding
+        tensor into ``input_hidden_states``.
+        """
+        self.input_data.copy_to_input_buffer()
+        if self._pending_mm_ctx is not None:
+            ctx = self._pending_mm_ctx
+            self._pending_mm_ctx = None
+            input_embeddings = self._mm_prepare_gpu(ctx)
+            self.input_data.set_mrope_position(ctx["mrope_positions"])
+            self.prepare_input_embeddings(input_embeddings)
 
     def _run_forward_on_stream(self, num_cal_tokens: int) -> int:
         if self.check_decode_batch():
@@ -561,11 +700,25 @@ class OverlapModelRunner(ModelRunner):
         self._next_tokens_buf_idx = 1 - buf_idx
         next_tokens_cpu = self._next_tokens_bufs[buf_idx]
 
-        with torch.cuda.stream(self.forward_stream):
-            future_indices = self.future_map.alloc_future_indices(batch_size)
-            future_slot_ids = future_indices.indices.cpu().tolist()
+        # ``future_slot_ids`` is purely a CPU concept (used by the scheduler
+        # for deferred output finalize). Derive it from the allocator's CPU
+        # state instead of materializing a GPU tensor and yanking it back
+        # via ``.cpu().tolist()`` -- that round-trip used to insert a hidden
+        # ``cudaStreamSynchronize`` on every batch.
+        future_indices = self.future_map.alloc_future_indices(batch_size)
+        future_slot_ids = list(
+            range(future_indices.interval.start, future_indices.interval.stop)
+        )
 
-            self.forward_stream.wait_stream(torch.cuda.current_stream())
+        # Capture the *outer* stream (default stream in the worker thread)
+        # so that ``forward_stream`` can correctly wait on H2D copies and
+        # multimodal embed work that ``prepare_input_gpu`` issued there.
+        # The previous code called ``wait_stream(torch.cuda.current_stream())``
+        # from *inside* the ``with cuda.stream(forward_stream)`` block, which
+        # resolved to a self-wait (no-op).
+        default_stream = torch.cuda.current_stream()
+        with torch.cuda.stream(self.forward_stream):
+            self.forward_stream.wait_stream(default_stream)
             self.future_map.resolve_future(
                 self.input_data.tokens[:num_cal_tokens]
             )

--- a/gllm/model_runner.py
+++ b/gllm/model_runner.py
@@ -292,8 +292,8 @@ class ModelRunner:
             in_decode = False
             if seq.seq_id not in self.embedding_cache:
                 mm_input: Dict = {}
-                image_grid_thw: torch.Tensor = None
-                video_grid_thw: torch.Tensor = None
+                image_grid_thw: Optional[torch.Tensor] = None
+                video_grid_thw: Optional[torch.Tensor] = None
                 if seq.mm_contents is not None:
                     if len(seq.mm_contents["image"]) != 0:
                         images = load_images(seq.mm_contents["image"])
@@ -314,11 +314,29 @@ class ModelRunner:
                         mm_input.update(videos_input)
                         video_grid_thw = videos_input["video_grid_thw"]
 
-                input_ids_cpu = torch.tensor(seq.token_ids)
-                placeholder_token_id = torch.tensor(
-                    self.model.get_mm_placeholder_token_ids()
+                # ``get_input_positions`` does per-element Python indexing on
+                # the grid tensors; if a fast image processor handed us CUDA
+                # tensors here, that loop would issue a D2H sync per element.
+                # Force CPU once, cheaply, so the CPU phase stays CPU-only.
+                if isinstance(image_grid_thw, torch.Tensor):
+                    image_grid_thw = image_grid_thw.cpu()
+                if isinstance(video_grid_thw, torch.Tensor):
+                    video_grid_thw = video_grid_thw.cpu()
+
+                # Explicitly pin these tensors to CPU. The repo sets the
+                # default device to CUDA via ``ModelLoader``, so a bare
+                # ``torch.tensor(...)`` would silently allocate on GPU and
+                # the ``torch.isin`` below would launch a kernel on the
+                # default stream -- defeating overlap with the previous
+                # batch's forward. Materialization to CUDA is deferred to
+                # ``_mm_prepare_gpu`` right before ``embed_input_ids``.
+                input_ids_cpu = torch.tensor(seq.token_ids, device="cpu")
+                placeholder_token_id_cpu = torch.tensor(
+                    self.model.get_mm_placeholder_token_ids(), device="cpu"
                 )
-                is_multimodal = torch.isin(input_ids_cpu, placeholder_token_id)
+                is_multimodal_cpu = torch.isin(
+                    input_ids_cpu, placeholder_token_id_cpu
+                )
                 prompt_positions, mrope_position_delta = (
                     MRotaryEmbedding.get_input_positions(
                         input_tokens=seq.token_ids,
@@ -335,13 +353,11 @@ class ModelRunner:
                     {
                         "kind": "uncached",
                         "seq": seq,
-                        "input_ids": input_ids_cpu,
-                        "is_multimodal": is_multimodal,
+                        "input_ids_cpu": input_ids_cpu,
+                        "is_multimodal_cpu": is_multimodal_cpu,
                         "mm_input": mm_input,
                         "prompt_positions": prompt_positions,
                         "mrope_position_delta": mrope_position_delta,
-                        "image_grid_thw": image_grid_thw,
-                        "video_grid_thw": video_grid_thw,
                     }
                 )
             else:
@@ -377,6 +393,7 @@ class ModelRunner:
         forward stream right before the model runs, so the placeholder content
         is irrelevant.
         """
+        device = self.input_hidden_states.device
         batch_embeddings: List[torch.Tensor] = []
         for work in ctx["prefill_works"]:
             seq = work["seq"]
@@ -385,18 +402,20 @@ class ModelRunner:
                 mm_input = work["mm_input"]
                 if mm_input:
                     mm_embeddings = self.model.embed_multimodal(**mm_input)
-                prompt_embeddings = self.model.embed_input_ids(
-                    work["input_ids"],
-                    mm_embeddings,
-                    work["is_multimodal"],
-                )
 
-                image_grid_thw = work["image_grid_thw"]
-                if image_grid_thw is not None:
-                    image_grid_thw = image_grid_thw.cpu()
-                video_grid_thw = work["video_grid_thw"]
-                if video_grid_thw is not None:
-                    video_grid_thw = video_grid_thw.cpu()
+                # Materialize CPU tensors built in ``_mm_prepare_cpu`` onto
+                # the model device for the embed kernels. Sources are small
+                # (one prompt's worth of ids) so a synchronous H2D is cheap
+                # and avoids the pageable-memory caveats of non_blocking.
+                input_ids = work["input_ids_cpu"].to(device, non_blocking=True)
+                is_multimodal = work["is_multimodal_cpu"].to(
+                    device, non_blocking=True
+                )
+                prompt_embeddings = self.model.embed_input_ids(
+                    input_ids,
+                    mm_embeddings,
+                    is_multimodal,
+                )
 
                 embedding_info = EmbeddingInfo(
                     prompt_embeddings,

--- a/gllm/overlap_worker.py
+++ b/gllm/overlap_worker.py
@@ -85,8 +85,16 @@ class OverlapWorker(Worker):
         return input_data
 
     def _launch_batch(self, input_data: InputData):
+        # Split input prep into a CPU phase (safe to run while the previous
+        # batch is still on the GPU) and a GPU/H2D phase (must wait until the
+        # previous forward has released the shared input buffers). The CPU
+        # phase covers attribute copies, multimodal position calc, and
+        # whatever image processing was deferred from the prefetch step;
+        # those several milliseconds of Python work now overlap with the
+        # tail of the previous forward instead of serializing behind it.
+        self.model_runner.prepare_input_cpu(input_data)
         self.model_runner.sync_before_next_prepare()
-        self.model_runner.prepare_input(input_data=input_data)
+        self.model_runner.prepare_input_gpu()
         return self.model_runner.run_batch_async()
 
     def _collect_batch(self, pending_entry, deferred_seqs=None):


### PR DESCRIPTION
- Before this PR
```
============ Serving Benchmark Result ============
Backend:                                 vllm      
Traffic request rate:                    inf       
Max request concurrency:                 32        
Successful requests:                     3000      
Benchmark duration (s):                  364.82    
Total input tokens:                      3072000   
Total input text tokens:                 3072000   
Total generated tokens:                  192000    
Total generated tokens (retokenized):    191737    
Request throughput (req/s):              8.22      
Input token throughput (tok/s):          8420.63   
Output token throughput (tok/s):         526.29    
Peak output token throughput (tok/s):    1989.00   
Peak concurrent requests:                61        
Total token throughput (tok/s):          8946.92   
Concurrency:                             31.94     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   3884.67   
Median E2E Latency (ms):                 3882.99   
P90 E2E Latency (ms):                    3915.53   
P99 E2E Latency (ms):                    4001.53   
---------------Time to First Token----------------
Mean TTFT (ms):                          1577.34   
Median TTFT (ms):                        1689.52   
P99 TTFT (ms):                           2383.56   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          36.62     
Median TPOT (ms):                        34.80     
P99 TPOT (ms):                           58.03     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           36.66     
Median ITL (ms):                         11.08     
P95 ITL (ms):                            206.11    
P99 ITL (ms):                            696.89    
Max ITL (ms):                            1507.70   
==================================================
```
- After this PR
```
============ Serving Benchmark Result ============
Backend:                                 vllm      
Traffic request rate:                    inf       
Max request concurrency:                 32        
Successful requests:                     3000      
Benchmark duration (s):                  347.44    
Total input tokens:                      3072000   
Total input text tokens:                 3072000   
Total generated tokens:                  192000    
Total generated tokens (retokenized):    191737    
Request throughput (req/s):              8.63      
Input token throughput (tok/s):          8841.70   
Output token throughput (tok/s):         552.61    
Peak output token throughput (tok/s):    1991.00   
Peak concurrent requests:                63        
Total token throughput (tok/s):          9394.31   
Concurrency:                             31.94     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   3699.66   
Median E2E Latency (ms):                 3693.37   
P90 E2E Latency (ms):                    3734.07   
P99 E2E Latency (ms):                    3838.40   
---------------Time to First Token----------------
Mean TTFT (ms):                          1584.16   
Median TTFT (ms):                        1778.74   
P99 TTFT (ms):                           2427.03   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          33.58     
Median TPOT (ms):                        30.38     
P99 TPOT (ms):                           56.50     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           33.61     
Median ITL (ms):                         8.40      
P95 ITL (ms):                            103.93    
P99 ITL (ms):                            693.35    
Max ITL (ms):                            1387.25   
==================================================
```

### Qwen2.5-VL-7B-Instruct

|                 Tasks                 |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|---------------------------------------|------:|------|-----:|------|---|-----:|---|-----:|
|mmmu_val                               |      0|none  |      |acc   |   |0.5044|±  |0.0162|