### PR TITLE
Opt overlap

### DIFF
--- a/gllm/async_utils.py
+++ b/gllm/async_utils.py
@@ -72,7 +72,24 @@ class FutureMap:
 
 
 class OverlapRuntime:
-    """CUDA streams used to overlap scheduling, forward, and D2H copies."""
+    """CUDA streams used to overlap scheduling, forward, and D2H copies.
+
+    Three streams form the GPU-side pipeline:
+
+    * ``prep_stream``    — H2D copies of input metadata + (for VL) multimodal
+                           embed work for the *next* batch. GPU-waits for the
+                           previous forward via ``input_consumed_event`` so it
+                           can be enqueued from the host without ever blocking.
+    * ``forward_stream`` — model forward + sample for the current batch.
+                           GPU-waits for ``prep_stream`` via
+                           ``input_ready_event``.
+    * ``copy_stream``    — D2H sample-id copy back to a pinned host buffer.
+
+    With this pipeline the host thread never calls ``cudaEventSynchronize``
+    between batches: every cross-stream dependency is expressed through events
+    that the GPU itself blocks on, so dispatch for batch N+1 can race ahead of
+    forward N as far as the schedule queue allows.
+    """
 
     def __init__(self, device: Union[torch.device, str]):
         self.device = (
@@ -80,4 +97,12 @@ class OverlapRuntime:
         )
         self.forward_stream = torch.cuda.Stream(device=self.device)
         self.copy_stream = torch.cuda.Stream(device=self.device)
+        self.prep_stream = torch.cuda.Stream(device=self.device)
+        # ``input_consumed_event``: signalled at the end of forward+sample on
+        # ``forward_stream``; the next batch's ``prep_stream`` waits on it
+        # before overwriting the shared input buffers.
         self.input_consumed_event = torch.cuda.Event()
+        # ``input_ready_event``: signalled by ``prep_stream`` after H2D and any
+        # VL embed work; ``forward_stream`` waits on it before reading the
+        # input buffers.
+        self.input_ready_event = torch.cuda.Event()

--- a/gllm/input_data.py
+++ b/gllm/input_data.py
@@ -199,7 +199,14 @@ class InputData:
                 if seq.to_compute_tokens is None
                 else seq.to_compute_tokens
             )
-        return torch.tensor(tokens_list, dtype=torch.long, device="cpu")
+        # Pin the CPU staging buffer so the H2D into ``self.tokens`` issued
+        # from ``copy_to_input_buffer`` with ``non_blocking=True`` is truly
+        # async on the prep stream. Pageable sources cause CUDA to fall back
+        # to a synchronous staging copy, which would defeat the host/GPU
+        # overlap the rest of the pipeline relies on.
+        return torch.tensor(
+            tokens_list, dtype=torch.long, device="cpu", pin_memory=True
+        )
 
     def get_tokens(self):
         return self.tokens[: self.tokens_cpu.shape[0]]
@@ -208,7 +215,9 @@ class InputData:
         positions_list = []
         for seq in seqs:
             positions_list.extend(range(seq.computed_token_num, seq.seq_len))
-        return torch.tensor(positions_list, dtype=torch.long, device="cpu")
+        return torch.tensor(
+            positions_list, dtype=torch.long, device="cpu", pin_memory=True
+        )
 
     def get_position(self):
         if self.mrope_positions_cpu is not None:
@@ -234,9 +243,17 @@ class InputData:
 
     def _cal_query_start_loc(self, seqs: List[Sequence]):
         query_lens = [0] + [seq.to_compute_token_num for seq in seqs]
-        return max(query_lens), torch.from_numpy(np.cumsum(query_lens)).to(
-            device="cpu", dtype=torch.int32
+        cumsum = np.cumsum(query_lens, dtype=np.int32)
+        # Materialize into a fresh pinned tensor so downstream non_blocking
+        # H2D doesn't have to fall back to a synchronous staging copy.
+        # ``device="cpu"`` is required because ``ModelLoader`` sets the
+        # default torch device to CUDA, and ``pin_memory=True`` is only
+        # legal on dense CPU tensors.
+        out = torch.empty(
+            cumsum.shape[0], dtype=torch.int32, device="cpu", pin_memory=True
         )
+        out.copy_(torch.from_numpy(cumsum))
+        return max(query_lens), out
 
     def get_query_start_loc(self):
         return self.query_start_loc[: self.query_start_loc_cpu.shape[0]]
@@ -248,7 +265,12 @@ class InputData:
         )
         for idx, block_table in enumerate(block_tables_list):
             block_tables[idx, : len(block_table)] = block_table
-        return torch.from_numpy(block_tables)
+        # See ``_cal_query_start_loc`` for why ``device="cpu"`` is required.
+        out = torch.empty(
+            block_tables.shape, dtype=torch.int32, device="cpu", pin_memory=True
+        )
+        out.copy_(torch.from_numpy(block_tables))
+        return out
 
     def get_block_table(self):
         return self.block_table[: self.block_table_cpu.shape[0]]
@@ -262,7 +284,9 @@ class InputData:
                 slot_mapping.append(
                     seq.page_table[page_idx] * self.page_size + slot_idx
                 )
-        return torch.tensor(slot_mapping, dtype=torch.int64, device="cpu")
+        return torch.tensor(
+            slot_mapping, dtype=torch.int64, device="cpu", pin_memory=True
+        )
 
     def get_slot_mapping(self):
         return self.slot_mapping[: self.slot_mapping_cpu.shape[0]]

--- a/gllm/model_runner.py
+++ b/gllm/model_runner.py
@@ -19,6 +19,7 @@ from gllm.async_utils import FutureMap, OverlapRuntime
 from gllm.dist_utils import (
     get_local_rank,
     get_output_rank,
+    get_tp_group,
     get_tp_size,
     is_first_pp_rank,
     is_last_pp_rank,
@@ -511,7 +512,18 @@ class ModelRunner:
             )
 
     @torch.inference_mode()
-    def capture_graph(self):
+    def capture_graph(self, stream: Optional[torch.cuda.Stream] = None):
+        """Capture per-bucket decode CUDA graphs.
+
+        ``stream`` controls which CUDA stream the graph is captured on.
+        ``torch.cuda.graph`` otherwise allocates a brand-new private stream
+        each call, which is fine for kernels but interacts poorly with
+        captured NCCL ops if replay later happens on a *different* stream
+        (the symptom we hit in TP+overlap runs was gradual KV-cache drift
+        between TP ranks surfacing as repetition loops). Subclasses that
+        replay on a known stream (e.g. ``OverlapModelRunner.forward_stream``)
+        should pass that same stream here so capture and replay agree.
+        """
         iterator = self.capture_sizes
         if get_local_rank() == 0:
             logger.info(f"Capturing CUDA graphs for bucket sizes: {list(reversed(self.capture_sizes))}")
@@ -523,7 +535,7 @@ class ModelRunner:
             if self.use_mm:
                 self.input_data.set_mrope_position(torch.zeros((3, size), device="cpu"))
             g = torch.cuda.CUDAGraph()
-            with torch.cuda.graph(cuda_graph=g, pool=memory_pool):
+            with torch.cuda.graph(cuda_graph=g, pool=memory_pool, stream=stream):
                 self.forward()
             self.size_to_graph[size] = g
         if torch.distributed.is_initialized():
@@ -607,14 +619,34 @@ class OverlapModelRunner(ModelRunner):
     """ModelRunner with FutureMap-based overlap scheduling (TP, pp_size=1 only)."""
 
     def init(self, mp_load_progress=None):
-        super().init(mp_load_progress)
-        self.init_overlap()
-
-    def init_overlap(self, num_prefill_chunks: int = 256) -> None:
+        # Create the overlap CUDA streams BEFORE ``super().init()`` so that
+        # ``capture_graph`` (invoked from inside ``super().init()``) can use
+        # ``forward_stream`` as the capture stream. Capturing on the same
+        # stream that ``run_batch_async`` replays on keeps the NCCL kernels
+        # baked into the graph tied to a single CUDA stream across capture
+        # and replay -- mismatch had caused TP ranks to subtly disagree
+        # after many decode steps and surface as repetition loops in long
+        # generations.
         device = torch.device(f"cuda:{get_local_rank()}")
         self.overlap_runtime = OverlapRuntime(device)
         self.forward_stream = self.overlap_runtime.forward_stream
         self.copy_stream = self.overlap_runtime.copy_stream
+        super().init(mp_load_progress)
+        self._init_overlap_buffers()
+
+    def capture_graph(self, stream: Optional[torch.cuda.Stream] = None):
+        # Capture on ``forward_stream`` so capture stream == replay stream.
+        # NCCL kernels (e.g. ``embed_tokens`` all_reduce, layer all_reduces)
+        # baked into the graph stay tied to the same CUDA stream across
+        # capture and replay. Without this they were captured on a fresh
+        # private stream that ``torch.cuda.graph`` allocates by default,
+        # then replayed on ``forward_stream`` -- the resulting NCCL/stream
+        # mismatch was letting TP ranks subtly drift over many decode
+        # iterations and produce the long-generation repetition loops.
+        super().capture_graph(stream=self.forward_stream)
+
+    def _init_overlap_buffers(self, num_prefill_chunks: int = 256) -> None:
+        device = self.forward_stream.device
         self.future_map = FutureMap(
             max_running_requests=self.max_running_seqs,
             context_len=self.model_max_length,
@@ -789,9 +821,18 @@ class OverlapModelRunner(ModelRunner):
                         dtype=torch.long,
                         device=self.input_data.tokens.device,
                     )
+                # Use the TP group so that this broadcast goes through the
+                # same NCCL communicator as the model's all_reduces. Sharing
+                # one communicator means NCCL's per-communicator FIFO
+                # ordering implicitly serializes broadcast vs all_reduce
+                # within a rank, removing a class of cross-communicator
+                # ordering hazards that were occasionally letting TP ranks
+                # store stale tokens into ``token_ids_buf`` and surface as
+                # repetition loops in long generations.
                 dist.broadcast(
                     next_tokens_gpu,
                     src=get_output_rank(),
+                    group=get_tp_group(),
                 )
             self.future_map.store_to_map(future_indices, next_tokens_gpu)
             if is_output_rank():

--- a/gllm/model_runner.py
+++ b/gllm/model_runner.py
@@ -646,16 +646,24 @@ class OverlapModelRunner(ModelRunner):
         )
 
     def sync_before_next_prepare(self) -> None:
-        self.overlap_runtime.input_consumed_event.synchronize()
+        """Deprecated host-side barrier; kept for backward compatibility.
+
+        The fully-async overlap pipeline expresses the
+        "previous forward has released the input buffers" dependency on the
+        GPU side via ``input_consumed_event`` and ``prep_stream``, so callers
+        should no longer need this. The method is intentionally a no-op now;
+        we keep the symbol so that any external user gets a smooth migration.
+        """
+        return
 
     def prepare_input_cpu(self, input_data: InputData) -> None:
         """CPU-only portion of input prep.
 
         Safe to invoke while the previous batch's forward is still consuming
-        the shared GPU input buffers. The pair :meth:`prepare_input_gpu` must
-        be called once :meth:`sync_before_next_prepare` has released those
-        buffers; only then is it sound to issue the H2D copies and write to
-        ``input_hidden_states``.
+        the shared GPU input buffers — this only touches Python attributes
+        and CPU tensors. The companion :meth:`prepare_input_gpu` issues the
+        actual H2D and embed work on ``prep_stream``, which itself
+        GPU-waits for the previous forward via ``input_consumed_event``.
         """
         self.input_data.set_input_from_prebuilt_cpu(input_data)
         if self.use_mm and is_first_pp_rank():
@@ -668,20 +676,35 @@ class OverlapModelRunner(ModelRunner):
             self._pending_mm_ctx = None
 
     def prepare_input_gpu(self) -> None:
-        """GPU/H2D portion of input prep.
+        """GPU/H2D portion of input prep, fully async.
 
-        Must run after :meth:`sync_before_next_prepare`. Performs the H2D
-        copies into the shared input buffers, runs the deferred multimodal
-        embedding work for any prefill seqs, and writes the merged embedding
-        tensor into ``input_hidden_states``.
+        All work (H2D copies into the shared input buffers, deferred
+        multimodal embed for prefill seqs, scattering decode embeddings) is
+        enqueued on ``prep_stream``. ``prep_stream`` first GPU-waits on
+        ``input_consumed_event`` so the writes can't clobber input buffers
+        that the previous batch's forward is still reading. After the work
+        is queued we record ``input_ready_event`` so that
+        :meth:`run_batch_async` can have ``forward_stream`` GPU-wait on it.
+
+        The host thread never blocks here: the ``cudaEventSynchronize`` that
+        used to serialize batches has been replaced by GPU-side
+        ``cudaStreamWaitEvent`` and stream events.
         """
-        self.input_data.copy_to_input_buffer()
-        if self._pending_mm_ctx is not None:
-            ctx = self._pending_mm_ctx
-            self._pending_mm_ctx = None
-            input_embeddings = self._mm_prepare_gpu(ctx)
-            self.input_data.set_mrope_position(ctx["mrope_positions"])
-            self.prepare_input_embeddings(input_embeddings)
+        rt = self.overlap_runtime
+        # GPU-side wait: prep_stream blocks until the previous forward has
+        # finished reading the input buffers. ``wait_event`` on an unrecorded
+        # event is a no-op (CUDA semantics), so this is safe on the very
+        # first iteration.
+        rt.prep_stream.wait_event(rt.input_consumed_event)
+        with torch.cuda.stream(rt.prep_stream):
+            self.input_data.copy_to_input_buffer()
+            if self._pending_mm_ctx is not None:
+                ctx = self._pending_mm_ctx
+                self._pending_mm_ctx = None
+                input_embeddings = self._mm_prepare_gpu(ctx)
+                self.input_data.set_mrope_position(ctx["mrope_positions"])
+                self.prepare_input_embeddings(input_embeddings)
+            rt.input_ready_event.record(rt.prep_stream)
 
     def _run_forward_on_stream(self, num_cal_tokens: int) -> int:
         if self.check_decode_batch():
@@ -729,14 +752,17 @@ class OverlapModelRunner(ModelRunner):
             range(future_indices.interval.start, future_indices.interval.stop)
         )
 
-        # Capture the *outer* stream (default stream in the worker thread)
-        # so that ``forward_stream`` can correctly wait on H2D copies and
-        # multimodal embed work that ``prepare_input_gpu`` issued there.
-        # The previous code called ``wait_stream(torch.cuda.current_stream())``
-        # from *inside* the ``with cuda.stream(forward_stream)`` block, which
-        # resolved to a self-wait (no-op).
+        # ``prepare_input_gpu`` enqueued all H2D + (VL) embed work on
+        # ``prep_stream`` and recorded ``input_ready_event``. ``forward_stream``
+        # GPU-waits on that event before reading the shared input buffers, so
+        # the pipeline is fully async (no host-side ``cudaEventSynchronize``).
+        # We additionally wait_stream(default_stream) defensively in case any
+        # incidental work landed on the worker thread's default stream
+        # (e.g. user-issued ops outside the overlap path); that's a no-op in
+        # the steady state.
         default_stream = torch.cuda.current_stream()
         with torch.cuda.stream(self.forward_stream):
+            self.forward_stream.wait_event(self.overlap_runtime.input_ready_event)
             self.forward_stream.wait_stream(default_stream)
             self.future_map.resolve_future(
                 self.input_data.tokens[:num_cal_tokens]

--- a/gllm/overlap_worker.py
+++ b/gllm/overlap_worker.py
@@ -85,20 +85,24 @@ class OverlapWorker(Worker):
         return input_data
 
     def _launch_batch(self, input_data: InputData):
-        # Split input prep into a CPU phase (safe to run while the previous
-        # batch is still on the GPU) and a GPU/H2D phase (must wait until the
-        # previous forward has released the shared input buffers). The CPU
-        # phase covers attribute copies, multimodal position calc, and
-        # whatever image processing was deferred from the prefetch step;
-        # those several milliseconds of Python work now overlap with the
-        # tail of the previous forward instead of serializing behind it.
+        # Pipelined input prep:
+        #   * ``prepare_input_cpu`` is pure CPU work and overlaps with the
+        #     previous batch's GPU forward.
+        #   * ``prepare_input_gpu`` enqueues H2D + (VL) embed work on the
+        #     overlap runtime's ``prep_stream``, which GPU-waits for the
+        #     previous batch's ``input_consumed_event``. There is no
+        #     host-side sync here -- the ordering is entirely expressed via
+        #     CUDA events, so the host thread races ahead and the GPU bubble
+        #     between back-to-back forwards collapses to the cross-stream
+        #     wait_event cost.
+        #   * ``run_batch_async`` then dispatches forward+sample on
+        #     ``forward_stream`` with a wait_event on ``input_ready_event``.
         self.model_runner.prepare_input_cpu(input_data)
-        self.model_runner.sync_before_next_prepare()
         self.model_runner.prepare_input_gpu()
         return self.model_runner.run_batch_async()
 
     def _collect_batch(self, pending_entry, deferred_seqs=None):
-        copy_done, batch_size, buf_idx = pending_entry
+        copy_done, batch_size, buf_idx, _input_data = pending_entry
         copy_done.synchronize()
         if is_output_rank():
             tokens = self.model_runner._next_tokens_bufs[buf_idx][
@@ -123,31 +127,53 @@ class OverlapWorker(Worker):
         pending_before = len(self._gpu_pending)
 
         if self._prefetched_input is not None:
-            copy_done, batch_size, future_slot_ids, buf_idx = self._launch_batch(
-                self._prefetched_input
-            )
+            # ``input_data`` is kept alive in ``_gpu_pending`` until the batch
+            # finishes on the GPU. Without this, the only Python reference to
+            # this batch's CPU input tensors (``tokens_cpu``, ``slot_mapping_cpu``
+            # etc.) lives on ``model_runner.input_data`` and would be
+            # overwritten by the *next* iteration's ``prepare_input_cpu`` --
+            # potentially while ``prep_stream`` is still DMA'ing from those
+            # buffers. Holding the original ``InputData`` here makes the
+            # cross-batch lifetime explicit and trivially correct.
+            input_data = self._prefetched_input
             self._prefetched_input = None
+            copy_done, batch_size, future_slot_ids, buf_idx = self._launch_batch(
+                input_data
+            )
             deferred = self.scheduler.process_output_deferred(future_slot_ids)
-            self._gpu_pending.append((copy_done, batch_size, buf_idx, deferred))
+            self._gpu_pending.append(
+                (copy_done, batch_size, buf_idx, deferred, input_data)
+            )
 
         if pending_before > 0:
-            copy_done, batch_size, buf_idx, deferred = self._gpu_pending.popleft()
-            self._collect_batch((copy_done, batch_size, buf_idx), deferred)
+            copy_done, batch_size, buf_idx, deferred, input_data = (
+                self._gpu_pending.popleft()
+            )
+            self._collect_batch(
+                (copy_done, batch_size, buf_idx, input_data), deferred
+            )
 
     def run_first_tp(self):
         """TP followers (pp_rank == 0 only)."""
         pending_before = len(self._gpu_pending)
 
         if pending_before > 0:
-            copy_done, batch_size, buf_idx, _deferred = self._gpu_pending.popleft()
-            self._collect_batch((copy_done, batch_size, buf_idx))
+            copy_done, batch_size, buf_idx, _deferred, input_data = (
+                self._gpu_pending.popleft()
+            )
+            self._collect_batch((copy_done, batch_size, buf_idx, input_data))
 
         next_input = self._recv_prefetched_input()
         if next_input is not None:
             copy_done, batch_size, _future_slot_ids, buf_idx = self._launch_batch(
                 next_input
             )
-            self._gpu_pending.append((copy_done, batch_size, buf_idx, None))
+            # Keep ``next_input`` alive in the pending queue (see comment in
+            # ``run_driver``) so its CPU input tensors outlive the prep_stream
+            # DMA on the follower path too.
+            self._gpu_pending.append(
+                (copy_done, batch_size, buf_idx, None, next_input)
+            )
 
 
 def run_overlap_worker(worker: OverlapWorker):


### PR DESCRIPTION
- Before this PR

```
============ Serving Benchmark Result ============
Backend:                                 vllm      
Traffic request rate:                    inf       
Max request concurrency:                 32        
Successful requests:                     3000      
Benchmark duration (s):                  347.44    
Total input tokens:                      3072000   
Total input text tokens:                 3072000   
Total generated tokens:                  192000    
Total generated tokens (retokenized):    191737    
Request throughput (req/s):              8.63      
Input token throughput (tok/s):          8841.70   
Output token throughput (tok/s):         552.61    
Peak output token throughput (tok/s):    1991.00   
Peak concurrent requests:                63        
Total token throughput (tok/s):          9394.31   
Concurrency:                             31.94     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   3699.66   
Median E2E Latency (ms):                 3693.37   
P90 E2E Latency (ms):                    3734.07   
P99 E2E Latency (ms):                    3838.40   
---------------Time to First Token----------------
Mean TTFT (ms):                          1584.16   
Median TTFT (ms):                        1778.74   
P99 TTFT (ms):                           2427.03   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          33.58     
Median TPOT (ms):                        30.38     
P99 TPOT (ms):                           56.50     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           33.61     
Median ITL (ms):                         8.40      
P95 ITL (ms):                            103.93    
P99 ITL (ms):                            693.35    
Max ITL (ms):                            1387.25   
==================================================
```

- After this PR

```
============ Serving Benchmark Result ============
Backend:                                 vllm      
Traffic request rate:                    inf       
Max request concurrency:                 32        
Successful requests:                     3000      
Benchmark duration (s):                  345.91    
Total input tokens:                      3072000   
Total input text tokens:                 3072000   
Total generated tokens:                  192000    
Total generated tokens (retokenized):    191738    
Request throughput (req/s):              8.67      
Input token throughput (tok/s):          8880.87   
Output token throughput (tok/s):         555.05    
Peak output token throughput (tok/s):    2006.00   
Peak concurrent requests:                64        
Total token throughput (tok/s):          9435.92   
Concurrency:                             31.94     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   3683.24   
Median E2E Latency (ms):                 3682.55   
P90 E2E Latency (ms):                    3768.16   
P99 E2E Latency (ms):                    4483.10   
---------------Time to First Token----------------
Mean TTFT (ms):                          1735.13   
Median TTFT (ms):                        1794.70   
P99 TTFT (ms):                           3103.80   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          30.92     
Median TPOT (ms):                        30.38     
P99 TPOT (ms):                           56.61     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           30.95     
Median ITL (ms):                         8.00      
P95 ITL (ms):                            20.25     
P99 ITL (ms):                            797.57    
Max ITL (ms):                            1599.79   
==================================================
```

### Qwen2.5-VL-7B-Instruct

|                 Tasks                 |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|---------------------------------------|------:|------|-----:|------|---|-----:|---|-----:|
|mmmu_val                               |      0|none  |      |acc   |   |0.5133|±  |0.0162|