### PR TITLE
Opt cpu overhead

### DIFF
--- a/gllm/input_data.py
+++ b/gllm/input_data.py
@@ -240,16 +240,17 @@ class InputData:
 
     def _cal_query_start_loc(self, seqs: List[Sequence]):
         query_lens = [0] + [seq.to_compute_token_num for seq in seqs]
-        cumsum = np.cumsum(query_lens, dtype=np.int32)
-        # Materialize into a fresh pinned tensor so downstream non_blocking
-        # H2D doesn't have to fall back to a synchronous staging copy.
-        # ``device="cpu"`` is required because ``ModelLoader`` sets the
-        # default torch device to CUDA, and ``pin_memory=True`` is only
-        # legal on dense CPU tensors.
+        # Materialize directly into a pinned tensor so downstream non_blocking
+        # H2D doesn't have to fall back to a synchronous staging copy. We
+        # write the cumulative sum straight into the pinned buffer's numpy
+        # view to avoid the prior intermediate ``np.cumsum`` allocation +
+        # ``torch.from_numpy`` + ``copy_`` round-trip. ``device="cpu"`` is
+        # required because ``ModelLoader`` sets the default torch device to
+        # CUDA, and ``pin_memory=True`` is only legal on dense CPU tensors.
         out = torch.empty(
-            cumsum.shape[0], dtype=torch.int32, device="cpu", pin_memory=True
+            len(query_lens), dtype=torch.int32, device="cpu", pin_memory=True
         )
-        out.copy_(torch.from_numpy(cumsum))
+        np.cumsum(query_lens, dtype=np.int32, out=out.numpy())
         return max(query_lens), out
 
     def get_query_start_loc(self):
@@ -257,16 +258,38 @@ class InputData:
 
     def _cal_block_table(self, seqs: List[Sequence]):
         block_tables_list = [seq.page_table for seq in seqs]
-        block_tables = np.full(
-            (len(block_tables_list), self.max_num_block), 0, dtype=np.int32
-        )
-        for idx, block_table in enumerate(block_tables_list):
-            block_tables[idx, : len(block_table)] = block_table
-        # See ``_cal_query_start_loc`` for why ``device="cpu"`` is required.
+        bs = len(block_tables_list)
+        # Previously we (1) allocated a temporary ``np.full((bs, max_num_block),
+        # 0)`` (~1 MB on Qwen3-0.6B with model_max_length=131072 / page_size=16
+        # -> max_num_block=8192) and zero-filled it, (2) sparsely filled the
+        # ragged page-table rows into it, then (3) allocated a same-shape
+        # pinned tensor and copied the numpy buffer into it (a 1 MB host-to-
+        # pinned memcpy). Profiler showed that final ``out.copy_(...)`` taking
+        # 4-9 ms per batch -- it dominated cal_input. The host-side ``copy_``
+        # itself is normally <30us for 1 MB; the inflated wall-clock comes
+        # from (a) writing 1 MB twice (zero the numpy buffer, then memcpy
+        # it into the pinned buffer) which is bandwidth-bound and contends
+        # with the prior batch's still-in-flight H2D issued from the same
+        # caching-host-allocator pool, and (b) cold-page touches on freshly
+        # handed-out pinned slabs.
+        #
+        # Skip the intermediate numpy buffer: get a numpy view onto the pinned
+        # tensor directly, zero only that view, then sparsely fill. This drops
+        # one 1 MB CPU write and the from_numpy bookkeeping. Microbench shows
+        # ~2.9x speedup, real workload sees _cal_block_table mean drop from
+        # ~3.2ms to <1ms. See ``_cal_query_start_loc`` for why
+        # ``device="cpu"`` is required (default device is CUDA under
+        # ``ModelLoader``).
         out = torch.empty(
-            block_tables.shape, dtype=torch.int32, device="cpu", pin_memory=True
+            (bs, self.max_num_block),
+            dtype=torch.int32,
+            device="cpu",
+            pin_memory=True,
         )
-        out.copy_(torch.from_numpy(block_tables))
+        out_np = out.numpy()
+        out_np.fill(0)
+        for idx, block_table in enumerate(block_tables_list):
+            out_np[idx, : len(block_table)] = block_table
         return out
 
     def get_block_table(self):

--- a/gllm/overlap_worker.py
+++ b/gllm/overlap_worker.py
@@ -44,6 +44,22 @@ class OverlapWorker(Worker):
         if len(schedule_seqs) == 0:
             self._prefetched_input = None
             return
+        # Ship ``schedule_seqs`` to the TP followers (same PP stage) BEFORE
+        # building this batch's ``InputData`` locally. ``cal_input`` is pure
+        # numpy/torch CPU work (~ms-level for typical decode batches) that
+        # touches only read-only seq attributes, so it overlaps cleanly with
+        # the pickling + zmq send happening in the background sender thread
+        # and with the TP follower's own ``cal_input`` once it receives.
+        #
+        # Previously we sent *after* ``cal_input`` returned, which meant
+        # rank-1 started its CPU prep ~``cal_input`` later than rank-0 every
+        # batch. That lag propagated all the way to the first NCCL collective
+        # of each forward and surfaced as a huge stall on rank-0's first
+        # AllReduce per batch (profiler: rank-0 AR p99 ~4ms, mean 87us; rank-1
+        # AR p99 ~80us, mean 11us). Sending first collapses that lag and lets
+        # the two ranks enter every collective ~simultaneously.
+        if get_world_size() > 1:
+            self.comm.send_schedule_seqs(schedule_seqs, None, True)
         next_input = InputData(
             use_buffer=False,
             memory_manager=self.model_runner.memory_manager,
@@ -51,7 +67,11 @@ class OverlapWorker(Worker):
         )
         next_input.cal_input(schedule_seqs)
         if get_world_size() > 1:
-            self.comm.send_schedule_seqs(schedule_seqs, None, True)
+            # Second send carries ``mrope_positions_cpu``, which is only
+            # populated by ``cal_input`` (and only used by subsequent PP
+            # stages for multimodal models). With pp_size=1 the recipient
+            # list is empty, so this is a no-op; with pp_size>1 it must
+            # remain after ``cal_input``.
             self.comm.send_schedule_seqs(
                 schedule_seqs, next_input.mrope_positions_cpu, False
             )


### PR DESCRIPTION
# TP=2 性能优化总结

针对暴露出的 gLLM TP=2 性能问题做了两处修复，在 Qwen3-0.6B、GPU 4,5、1024-input / 256-output workload 上 **req/s +38%、TPOT -29%、run-to-run 方差从 ±13% 收敛到 ±0.5%**。

## 问题定位

profile 里同一个 AllReduce 在两张卡上耗时分布差距巨大：

| metric | rank-0 (baseline) | rank-1 (baseline) |
|---|---|---|
| AR mean | 87.2 us | 10.8 us |
| AR p99 | **4135 us** | 81 us |
| AR max | **11184 us** | 88 us |
| AR total | 337.8 ms | 42.0 ms |

每 batch 的"第一个 AR"在 rank-0 上 stall 几毫秒，等 rank-1 进入同一个 collective。再追下去发现两个根因：

1. **rank-1 比 rank-0 晚启动 ~3.5 ms** —— `_build_prefetched_input` 把 `cal_input` 跑完才通过 zmq 把 schedule 发给 rank-1。
2. **`_cal_block_table` 每 batch 3.2 ms（最坏 9.7 ms）** —— Qwen3-0.6B 的 `max_num_block = 8192`，每 batch 都要 `np.full(1MB, 0)` + `torch.empty(pin_memory=True)` + `out.copy_(torch.from_numpy(...))`。最后那条 host-to-pinned memcpy 占了 95% 的时间，原因是 pinned caching-host-allocator 在重用上一批 H2D 还没真正完成的 1MB slab，造成主机内存带宽竞争 + cold-page 触摸。

## 修复

### 1. `gllm/overlap_worker.py` — 提前向 TP follower 发送 schedule

```python
# Ship schedule_seqs to TP followers BEFORE building this batch's InputData
if get_world_size() > 1:
    self.comm.send_schedule_seqs(schedule_seqs, None, True)
next_input = InputData(...)
next_input.cal_input(schedule_seqs)
# Second send (mrope_positions) stays AFTER cal_input; with pp_size=1 it's a no-op
if get_world_size() > 1:
    self.comm.send_schedule_seqs(schedule_seqs, next_input.mrope_positions_cpu, False)
```

让 rank-1 一拿到 seqs 就能并发跑自己的 `cal_input`，与 rank-0 几乎同时进入 forward。`cal_input` 是纯只读 numpy/torch CPU 工作，提前 pickle + send 安全。

### 2. `gllm/input_data.py` — 跳掉中间 1MB 拷贝

```python
def _cal_block_table(self, seqs):
    block_tables_list = [seq.page_table for seq in seqs]
    bs = len(block_tables_list)
    out = torch.empty(
        (bs, self.max_num_block),
        dtype=torch.int32, device="cpu", pin_memory=True,
    )
    out_np = out.numpy()        # 零拷贝 view 到 pinned 内存
    out_np.fill(0)
    for idx, block_table in enumerate(block_tables_list):
        out_np[idx, : len(block_table)] = block_table
    return out
```

直接拿 pinned 张量的 numpy view 写，省掉一次额外 1MB host-to-host memcpy。`_cal_query_start_loc` 用了同样的反模式，顺手改成 `np.cumsum(..., out=pinned.numpy())`。

**关键点**：保留 `(bs, max_num_block)` 完整宽度，FA 看到的页表布局和 baseline 完全一致 —— 避免上次裁剪列宽时踩到的 FlashAttention varlen 缓存回归。

## 验证

### 性能（GPU 4,5, TP=2, random 1024/256, 3-run 平均）

256 prompts @ 并发 64：

| metric | baseline | +overlap-fix | **+overlap +input-fix** | gain |
|---|---|---|---|---|
| 吞吐 | 18.6 req/s | ~19.1 req/s | **25.7 req/s** | **+38%** |
| TPOT 均值 | 12.6 ms | ~12.2 ms | **8.9 ms** | **-29%** |
| Output | 4765 tok/s | 4876 tok/s | **6587 tok/s** | **+38%** |
| Run-to-run 方差 | ±13% | ±9% | **±0.5%** | 几乎消失 |

512 prompts @ 并发 128（更高并发下 GPU 接近饱和）：

| metric | baseline | optimized | gain |
|---|---|---|---|
| 吞吐 | 28.2 req/s | **31.1 req/s** | +10% |
| TPOT | 16.5 ms | **14.9 ms** | -10% |
| Output | 7227 tok/s | **7970 tok/s** | +10% |

### Profile 层面 (rank-0)

| metric | baseline | optimized | gain |
|---|---|---|---|
| AR mean | 87.2 us | **49.4 us** | -43% |
| AR p99 | 4135 us | **1090 us** | -74% |
| AR max | 11184 us | **5596 us** | -50% |
| `_cal_block_table` mean | 3239 us | **157 us** | -95% |
| `cal_input` total | 527 ms | **94 ms** | -82% |
| `aten::copy_` total | 434 ms | 掉出 top 25 | — |
| FA kernel total | 323 ms | 323 ms | 不变（布局未变） |

### 正确性

- pinned 张量的 `.numpy()` 是零拷贝同内存 view，写 view 等价于写 pinned，语义和原 `np.full` + memcpy 完全一致。
- 单 prompt / 4 路并发 / 128-output 长生成都验过，输出语义正常，server.log 无 error/warn。
- FA kernel 用时未变，证明 GPU 端 block_table 布局完全等价。

## 还残留的瓶颈

1. **AR 仍是大头**：rank-0 AR 总时长 408 ms ≈ forward 总时长的 35%。Qwen3-0.6B `hidden=1024` 在 TP=2 下每层 ~64 KB 小消息是 NCCL ring 的硬伤。要进一步榨油需要加 vLLM/SGLang 那种 custom AllReduce (NVLink P2P 双 shot)。
2. **`gllm/comm.py:send_schedule_seqs`** 每次起新 `threading.Thread`，单次 ~50-100us，改持久 sender thread + queue 还能再省。
3. **`_cal_slot_mapping`** 现在是 cal_input 内最大头（~222 us 均值），Python 内层循环可向量化，但量级已经不大。

## 改动文件

- `gllm/overlap_worker.py`：`_build_prefetched_input` 提前 send
- `gllm/input_data.py`：`_cal_block_table` 直接写 pinned view；`_cal_query_start_loc` 同模式
