### PR TITLE
Fix qwen3 tool call

### DIFF
--- a/gllm/entrypoints/serving_chat.py
+++ b/gllm/entrypoints/serving_chat.py
@@ -27,7 +27,7 @@ async def chat_completion_generator(
     content = full_text
     tool_calls = []
     if tool_parser is not None and request.tools:
-        parsed_content, tool_calls = tool_parser.parse(full_text)
+        parsed_content, tool_calls = tool_parser.parse(full_text, request.tools)
         content = parsed_content if parsed_content is not None else ""
 
     choice_data = ChatCompletionResponseChoice(
@@ -59,7 +59,7 @@ async def chat_completion_stream_generator(
     # emits content fragments + tool-call name/argument fragments (tied by
     # ``index``), mirroring vLLM / SGLang. Otherwise stream raw text deltas.
     streaming = tool_parser is not None and bool(request.tools)
-    sp = tool_parser.stream_parser() if streaming else None
+    sp = tool_parser.stream_parser(request.tools) if streaming else None
     full_text = ""
 
     async for text in stream:

--- a/gllm/entrypoints/tool_parsers.py
+++ b/gllm/entrypoints/tool_parsers.py
@@ -24,8 +24,9 @@ the server leaves the raw text in ``content`` untouched.
 """
 
 import json
+import math
 import re
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from gllm.entrypoints.protocol import (
     DeltaFunctionCall,
@@ -47,16 +48,204 @@ def _dump_arguments(arguments) -> str:
         return "{}"
 
 
+# ── Schema-aware argument coercion ──────────────────────────────────────────
+# XML tool-call markup (Qwen3.5) carries no type information -- every
+# ``<parameter>`` value is raw text. To emit correctly-typed ``tool_calls`` we
+# coerce each value to the type declared in the tool's JSON schema: string-typed
+# params stay strings, while integer/number/boolean/array/object params are
+# converted. This mirrors the reference Qwen3 parser (vLLM) and is what makes
+# native tool-calling scores match: a consumer can turn ``"4"`` into an int when
+# the schema says integer, but a spurious ``json.loads`` that turns a string
+# ``"4"`` into ``int`` unconditionally breaks string-typed params (e.g. BFCL's
+# Java/JS categories, where every value is a string).
+
+_TYPE_ALIASES: Dict[str, str] = {
+    "str": "string", "text": "string", "varchar": "string", "char": "string",
+    "enum": "string", "int": "integer", "int32": "integer", "int64": "integer",
+    "uint": "integer", "long": "integer", "short": "integer", "float": "number",
+    "float32": "number", "float64": "number", "double": "number",
+    "bool": "boolean", "dict": "object", "arr": "array", "list": "array",
+    "sequence": "array", "tuple": "array",
+}
+
+
+def _extract_types_from_schema(schema: Any) -> List[str]:
+    """All possible JSON-Schema type strings for a property (handles ``type``
+    as str/list, ``enum`` inference and ``anyOf``/``oneOf``/``allOf``).
+    Defaults to ``["string"]`` when nothing can be determined."""
+    if not isinstance(schema, dict):
+        return ["string"]
+    types: set = set()
+    t = schema.get("type")
+    if isinstance(t, str):
+        types.add(t)
+    elif isinstance(t, list):
+        types.update(x for x in t if isinstance(x, str))
+    enum = schema.get("enum")
+    if isinstance(enum, list) and enum:
+        for v in enum:
+            if v is None:
+                types.add("null")
+            elif isinstance(v, bool):
+                types.add("boolean")
+            elif isinstance(v, int):
+                types.add("integer")
+            elif isinstance(v, float):
+                types.add("number")
+            elif isinstance(v, str):
+                types.add("string")
+            elif isinstance(v, list):
+                types.add("array")
+            elif isinstance(v, dict):
+                types.add("object")
+    for field in ("anyOf", "oneOf", "allOf"):
+        choices = schema.get(field)
+        if isinstance(choices, list):
+            for choice in choices:
+                types.update(_extract_types_from_schema(choice))
+    return list(types) if types else ["string"]
+
+
+def _json_finite(obj: Any) -> bool:
+    """JSON has no inf/nan; reject them so we never emit invalid JSON."""
+    if isinstance(obj, float):
+        return math.isfinite(obj)
+    if isinstance(obj, list):
+        return all(_json_finite(x) for x in obj)
+    if isinstance(obj, dict):
+        return all(_json_finite(v) for v in obj.values())
+    return True
+
+
+def _coerce_to_schema_type(value: str, schema_types) -> Any:
+    """Best-effort coercion of a raw string to a JSON-Schema type, trying
+    ``null > integer > number > boolean > object > array > string`` and
+    falling back to the original string when nothing fits."""
+    if isinstance(schema_types, str):
+        schema_types = [schema_types]
+    normalized = {
+        _TYPE_ALIASES.get(k, k)
+        for t in schema_types
+        for k in [str(t).strip().lower()]
+    }
+    for candidate in ("null", "integer", "number", "boolean", "object", "array", "string"):
+        if candidate not in normalized:
+            continue
+        if candidate == "null":
+            if value.strip().lower() == "null":
+                return None
+            continue
+        if candidate == "string":
+            return value
+        if candidate == "integer":
+            try:
+                return int(value)
+            except (ValueError, TypeError):
+                continue
+        if candidate == "number":
+            try:
+                val = float(value)
+            except (ValueError, TypeError):
+                continue
+            if not math.isfinite(val):
+                continue
+            return val if val != int(val) else int(val)
+        if candidate == "boolean":
+            low = value.strip().lower()
+            if low in ("true", "1"):
+                return True
+            if low in ("false", "0"):
+                return False
+            continue
+        if candidate in ("object", "array"):
+            try:
+                parsed = json.loads(value)
+            except (json.JSONDecodeError, ValueError, TypeError):
+                continue
+            if _json_finite(parsed):
+                return parsed
+            continue
+    # No declared type matched cleanly; try a plain JSON parse, else keep string.
+    try:
+        parsed = json.loads(value)
+    except (json.JSONDecodeError, ValueError):
+        return value
+    return parsed if _json_finite(parsed) else value
+
+
+def _coerce_value(value: Any, schema: Any) -> Any:
+    """Coerce a parsed value against its schema (recursing into object
+    ``properties`` and array ``items``)."""
+    if not isinstance(schema, dict):
+        return value
+    if isinstance(value, str):
+        return _coerce_to_schema_type(value, _extract_types_from_schema(schema))
+    if isinstance(value, dict):
+        props = schema.get("properties")
+        if isinstance(props, dict):
+            for k in list(value):
+                if isinstance(props.get(k), dict):
+                    value[k] = _coerce_value(value[k], props[k])
+        return value
+    if isinstance(value, list):
+        items = schema.get("items")
+        if isinstance(items, dict):
+            for i, item in enumerate(value):
+                value[i] = _coerce_value(item, items)
+        return value
+    return value
+
+
+def _properties_for(tools, func_name: str) -> Optional[Dict[str, Any]]:
+    """Find the ``parameters.properties`` schema map for ``func_name`` in the
+    request's ``tools`` (accepts pydantic tool params or plain dicts)."""
+    if not tools:
+        return None
+    for tool in tools:
+        fn = getattr(tool, "function", None)
+        if fn is None and isinstance(tool, dict):
+            fn = tool.get("function")
+        if fn is None:
+            continue
+        name = getattr(fn, "name", None)
+        params = getattr(fn, "parameters", None)
+        if isinstance(fn, dict):
+            name = fn.get("name")
+            params = fn.get("parameters")
+        if name != func_name:
+            continue
+        if isinstance(params, dict):
+            props = params.get("properties")
+            return props if isinstance(props, dict) else None
+        return None
+    return None
+
+
+def _coerce_args(args: Dict[str, Any], tools, func_name: str) -> Dict[str, Any]:
+    """Type-correct an all-string XML arg dict using the tool schema. A no-op
+    when no schema is available (values then stay strings)."""
+    props = _properties_for(tools, func_name)
+    if not props:
+        return args
+    for key in list(args):
+        schema = props.get(key)
+        if isinstance(schema, dict):
+            args[key] = _coerce_value(args[key], schema)
+    return args
+
+
 class ToolParser:
     """Base class. Subclasses set ``name`` and implement :meth:`parse` and
     :meth:`stream_parser`."""
 
     name: str = "base"
 
-    def parse(self, full_text: str) -> Tuple[Optional[str], List[ToolCall]]:
+    def parse(
+        self, full_text: str, tools=None
+    ) -> Tuple[Optional[str], List[ToolCall]]:
         raise NotImplementedError
 
-    def stream_parser(self) -> "StreamToolParser":
+    def stream_parser(self, tools=None) -> "StreamToolParser":
         raise NotImplementedError
 
 
@@ -68,8 +257,9 @@ class StreamToolParser:
     completed block) or ``None`` when there is nothing new to send yet.
     """
 
-    def __init__(self, parser: ToolParser) -> None:
+    def __init__(self, parser: ToolParser, tools=None) -> None:
         self._parser = parser
+        self._tools = tools
         self._content_emitted = 0
         self._tool_calls_emitted = 0
 
@@ -88,7 +278,7 @@ class StreamToolParser:
                 return DeltaMessage(content=new)
 
         # 2) Emit the next fully-formed tool call, if one is now available.
-        calls = self._parser.parse(full_text)[1]
+        calls = self._parser.parse(full_text, self._tools)[1]
         if len(calls) > self._tool_calls_emitted:
             idx = self._tool_calls_emitted
             call = calls[idx]
@@ -120,7 +310,9 @@ class QwenToolParser(ToolParser):
     def content_prefix(self, full_text: str) -> str:
         return full_text.split(self._START, 1)[0]
 
-    def parse(self, full_text: str) -> Tuple[Optional[str], List[ToolCall]]:
+    def parse(
+        self, full_text: str, tools=None
+    ) -> Tuple[Optional[str], List[ToolCall]]:
         if self._START not in full_text:
             return full_text, []
 
@@ -136,6 +328,7 @@ class QwenToolParser(ToolParser):
             name = obj.get("name")
             if not name:
                 continue
+            # Hermes JSON already carries native types; no schema coercion.
             tool_calls.append(
                 ToolCall(
                     function=FunctionCall(
@@ -148,8 +341,8 @@ class QwenToolParser(ToolParser):
         content = self.content_prefix(full_text).strip() or None
         return content, tool_calls
 
-    def stream_parser(self) -> StreamToolParser:
-        return StreamToolParser(self)
+    def stream_parser(self, tools=None) -> StreamToolParser:
+        return StreamToolParser(self, tools)
 
 
 class Qwen3ToolParser(ToolParser):
@@ -164,10 +357,18 @@ class Qwen3ToolParser(ToolParser):
         </function>
         </tool_call>
 
-    The chat template emits scalar arg values as bare text (``10``, ``units``,
-    ``true``) and dict/list values as JSON, so on parse we ``json.loads`` each
-    value and fall back to the raw string -- ints/floats/bools/arrays/objects
-    round-trip while plain strings stay strings.
+    Each ``<parameter>`` value comes out of the XML as raw text (no type
+    information). We type-correct it against the tool's JSON schema via
+    :func:`_coerce_args`: ``string`` params stay strings, while
+    ``integer``/``number``/``boolean``/``array``/``object`` params are coerced
+    to their real types. This mirrors the reference Qwen3 parser (vLLM). When no
+    schema is supplied the values simply stay strings.
+
+    Doing schema-*less* ``json.loads`` on every value (turning ``"4"`` into
+    ``int`` and ``"true"`` into ``bool`` unconditionally) is wrong -- it breaks
+    string-typed params (e.g. BFCL's Java/JS categories, where every value is a
+    string). Keeping *everything* a string is equally wrong -- it breaks numeric
+    Python params. The schema is the only reliable signal.
     """
 
     name = "qwen3"
@@ -175,21 +376,22 @@ class Qwen3ToolParser(ToolParser):
     _FUNC_RE = re.compile(
         r"<function=(?P<name>[^>\n]+)>(?P<body>.*?)</function>", re.DOTALL
     )
+    # Tolerate a missing/garbled closing ``</parameter>``: a value runs until
+    # its ``</parameter>``, the next ``<parameter=``, or the end of the function
+    # body (Qwen sometimes drops the final closing tag).
     _PARAM_RE = re.compile(
-        r"<parameter=(?P<key>[^>\n]+)>\n?(?P<val>.*?)\n?</parameter>", re.DOTALL
+        r"<parameter=(?P<key>[^>\n]+)>"
+        r"(?P<val>.*?)"
+        r"(?:</parameter>|(?=<parameter=)|\Z)",
+        re.DOTALL,
     )
 
     def content_prefix(self, full_text: str) -> str:
         return full_text.split(self._START, 1)[0]
 
-    @staticmethod
-    def _coerce(raw: str):
-        try:
-            return json.loads(raw)
-        except (json.JSONDecodeError, ValueError):
-            return raw
-
-    def parse(self, full_text: str) -> Tuple[Optional[str], List[ToolCall]]:
+    def parse(
+        self, full_text: str, tools=None
+    ) -> Tuple[Optional[str], List[ToolCall]]:
         if self._START not in full_text:
             return full_text, []
 
@@ -205,7 +407,10 @@ class Qwen3ToolParser(ToolParser):
             for pm in self._PARAM_RE.finditer(fm.group("body")):
                 key = pm.group("key").strip()
                 if key:
-                    args[key] = self._coerce(pm.group("val"))
+                    args[key] = pm.group("val").strip()
+            # Values come out of the XML as raw strings; type-correct them
+            # against the tool schema (string params stay strings).
+            args = _coerce_args(args, tools, name)
             tool_calls.append(
                 ToolCall(
                     function=FunctionCall(
@@ -217,8 +422,8 @@ class Qwen3ToolParser(ToolParser):
         content = self.content_prefix(full_text).strip() or None
         return content, tool_calls
 
-    def stream_parser(self) -> StreamToolParser:
-        return StreamToolParser(self)
+    def stream_parser(self, tools=None) -> StreamToolParser:
+        return StreamToolParser(self, tools)
 
 
 class KimiToolParser(ToolParser):
@@ -247,7 +452,9 @@ class KimiToolParser(ToolParser):
             fid = fid[len("functions.") :]
         return fid
 
-    def parse(self, full_text: str) -> Tuple[Optional[str], List[ToolCall]]:
+    def parse(
+        self, full_text: str, tools=None
+    ) -> Tuple[Optional[str], List[ToolCall]]:
         if self._SECTION_START not in full_text:
             return full_text, []
 
@@ -256,6 +463,7 @@ class KimiToolParser(ToolParser):
             name = self._name_from_id(m.group("fid"))
             if not name:
                 continue
+            # Kimi emits a JSON argument blob; pass it through unchanged.
             tool_calls.append(
                 ToolCall(
                     function=FunctionCall(
@@ -268,8 +476,8 @@ class KimiToolParser(ToolParser):
         content = self.content_prefix(full_text).strip() or None
         return content, tool_calls
 
-    def stream_parser(self) -> StreamToolParser:
-        return StreamToolParser(self)
+    def stream_parser(self, tools=None) -> StreamToolParser:
+        return StreamToolParser(self, tools)
 
 
 def _qwen_parser_for_arch(architecture: Optional[str]) -> ToolParser:


### PR DESCRIPTION
## BFCL-V4 full native suite (Qwen3.5-27B-FP8, 3641 entries)

| Category | n | gLLM native (before) | gLLM native (fixed) | vLLM native |
|---|---:|---:|---:|---:|
| simple_python | 400 | 87.00 | 96.00 | 95.25 |
| simple_java | 100 | 40.00 | 64.00 | 65.00 |
| simple_javascript | 50 | 34.00 | 72.00 | 74.00 |
| multiple | 200 | 87.00 | 95.50 | 95.50 |
| parallel | 200 | 84.00 | 93.00 | 93.50 |
| parallel_multiple | 200 | 77.50 | 91.50 | 91.50 |
| irrelevance | 240 | 90.00 | 90.42 | 90.00 |
| live_simple | 258 | 84.88 | 88.76 | 87.98 |
| live_multiple | 1053 | 67.43 | 82.53 | 83.00 |
| live_parallel | 16 | 93.75 | 93.75 | 93.75 |
| live_parallel_multiple | 24 | 70.83 | 83.33 | 83.33 |
| live_relevance | 16 | 75.00 | 81.25 | 75.00 |
| live_irrelevance | 884 | 81.11 | 81.22 | 80.66 |
| **MICRO (overall)** | **3641** | **77.12** | **85.83** | **85.72** |
| **MACRO (avg of cats)** | | **74.81** | **85.64** | **85.27** |