### PR TITLE
Unify cache allocation and optimize hybrid MTP

### DIFF
--- a/docs/encoder_disaggregation_usage.md
+++ b/docs/encoder_disaggregation_usage.md
@@ -250,14 +250,19 @@ one goes away, the LM watchdog re-dispatches its in-flight items to the others.
 
 ## 8. Memory tuning (hybrid models with SSM cache)
 
-Qwen3.5-family models have hybrid linear-attention. The LM's SSM snapshot pool
-scales as `~4 × maxd + 1` slots, so with the default `--maxd 512` the SSM cache
-can reach ~39 GB on a single TP1 GPU and OOM on top of the weights.
+Qwen3.5-family models have hybrid linear attention. KV pages, live recurrent
+state, MTP checkpoints and prefix-state snapshots all borrow physical bytes
+from one cache arena. There is no fixed SSM sub-pool or snapshot-count limit:
+the active workload determines the mix, and prefix snapshots are reclaimed in
+LRU order when KV or live recurrent state needs space.
 
-- If concurrency is moderate, lower `--maxd` (e.g. 64): SSM cache drops from
-  ~39 GB to ~5 GB.
-- Still OOM? Lower `--gpu-memory-util` or `--model-max-length`.
-- Dense models (Qwen2.5-VL) have no SSM cache and need no special handling.
+- `--gpu-memory-util` controls the total arena budget.
+- `--maxd` remains the scheduling concurrency bound, but does not preallocate
+  or reserve `maxd` SSM entries.
+- `--ssm-snapshot-stride-tokens` controls snapshot granularity, not capacity.
+  A larger stride reduces snapshot-copy work at the cost of recomputing a
+  longer prefix tail after a cache hit.
+- Dense models use the existing KV-only allocation path.
 
 ---
 

--- a/gllm/_custom_ops.py
+++ b/gllm/_custom_ops.py
@@ -57,6 +57,9 @@ from gllm.layers.ops.cache_kernels import (
 from gllm.layers.ops.batched_rotary_kernel import (
     batched_rotary_embedding as _triton_batched_rotary_embedding,
 )
+from gllm.layers.ops.gemma_rmsnorm import (
+    gemma_rms_norm_reference_reduction as _triton_gemma_rms_norm,
+)
 
 
 # =============================================================================
@@ -345,14 +348,10 @@ def gemma_rms_norm(
 ) -> None:
     """Gemma RMSNorm with the learned ``weight + 1`` applied in fp32.
 
-    sglang-kernel 0.4.6's SM100 kernel accumulates differently from the fp32
-    checkpoint reference, so retain the established gLLM numerical contract.
+    Keep the established FP32 ``aten::mean`` reduction order while fusing the
+    surrounding casts and pointwise work into compact Triton kernels.
     """
-    input_fp32 = input.float()
-    normalized = input_fp32 * torch.rsqrt(
-        input_fp32.square().mean(dim=-1, keepdim=True) + epsilon
-    )
-    out.copy_((normalized * (weight.float() + 1.0)).to(input.dtype))
+    _triton_gemma_rms_norm(out, input, weight, epsilon)
 
 
 def gemma_fused_add_rms_norm(
@@ -360,11 +359,7 @@ def gemma_fused_add_rms_norm(
 ) -> None:
     """In-place residual add followed by fp32-reference Gemma RMSNorm."""
     residual.add_(input)
-    residual_fp32 = residual.float()
-    normalized = residual_fp32 * torch.rsqrt(
-        residual_fp32.square().mean(dim=-1, keepdim=True) + epsilon
-    )
-    input.copy_((normalized * (weight.float() + 1.0)).to(input.dtype))
+    _triton_gemma_rms_norm(input, residual, weight, epsilon)
 
 
 # =============================================================================

--- a/gllm/engine/llm.py
+++ b/gllm/engine/llm.py
@@ -43,13 +43,10 @@ class LLM:
         gpu_memory_util=0.9,
         page_size=16,
         # ``maxd`` caps the number of concurrently running (decode) sequences,
-        # which also sizes ``max_running_seqs`` and -- for hybrid GDN/Mamba
-        # models -- the SSM working pool (``maxd`` slots) plus the prefix-cache
-        # snapshot pool (``4*maxd`` slots, each holding the full per-layer
-        # recurrent state). The previous default of 2048 made those pools tens
-        # of GiB on linear-attention models and OOM'd before the KV cache was
-        # even allocated. 512 matches the api/lm server ``--maxd`` default;
-        # lower it if the SSM/snapshot pools are too large for a given model.
+        # which also sizes ``max_running_seqs``. Hybrid GDN/Mamba models claim
+        # their working/checkpoint state dynamically from the same physical
+        # cache arena as KV; ``maxd`` is therefore an admission/buffer bound,
+        # not a separately preallocated SSM cache size.
         maxd=512,
         maxp=2048,
         minp=32,

--- a/gllm/layers/moe/flashinfer_trtllm.py
+++ b/gllm/layers/moe/flashinfer_trtllm.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+
+_EPILOGUE_TILE_M = 128
+_BLOCK_K = 128
+
+
+def bf16_moe_support_reason(layer: torch.nn.Module) -> Optional[str]:
+    """Return why the TRT-LLM BF16 MoE backend cannot serve ``layer``."""
+    if not torch.cuda.is_available():
+        return "CUDA is unavailable"
+    if torch.cuda.get_device_capability()[0] != 10:
+        return "TRT-LLM BF16 MoE requires an SM100-family GPU"
+    try:
+        from flashinfer.fused_moe import trtllm_bf16_moe
+    except (ImportError, AttributeError) as exc:
+        return f"FlashInfer TRT-LLM BF16 MoE is unavailable: {exc}"
+    if not callable(trtllm_bf16_moe):
+        return "flashinfer.fused_moe.trtllm_bf16_moe is not callable"
+
+    w13 = layer.w13_weight
+    w2 = layer.w2_weight
+    if w13.dtype != torch.bfloat16 or w2.dtype != torch.bfloat16:
+        return "TRT-LLM BF16 MoE requires bfloat16 expert weights"
+    if layer.global_num_experts > 2048:
+        return "TRT-LLM routing supports at most 2048 experts"
+    if layer.activation != "silu":
+        return f"TRT-LLM BF16 MoE does not support activation={layer.activation!r}"
+    if layer.apply_router_weight_on_input:
+        return "router weights on the GEMM1 input are unsupported"
+    if layer.scoring_func != "softmax":
+        return f"routing scoring_func={layer.scoring_func!r} is unsupported"
+    if layer.use_grouped_topk or layer.e_score_correction_bias is not None:
+        return "grouped or biased routing is unsupported by this dispatch"
+    if w13.shape[-1] * w13.element_size() % _BLOCK_K:
+        return "the GEMM1 K dimension is not aligned to 128 bytes"
+    if w2.shape[-1] * w2.element_size() % _BLOCK_K:
+        return "the GEMM2 K dimension is not aligned to 128 bytes"
+    if layer.intermediate_size_per_partition % 128:
+        return "the local intermediate size is not aligned to 128 elements"
+    return None
+
+
+def convert_bf16_moe_weights(
+    w13_weight: torch.Tensor,
+    w2_weight: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Convert ordinary expert matrices to TRT-LLM BlockMajorK layout."""
+    if w13_weight.dtype != torch.bfloat16 or w2_weight.dtype != torch.bfloat16:
+        raise ValueError("TRT-LLM BF16 MoE requires bfloat16 weights")
+
+    from flashinfer.fused_moe.core import (
+        _maybe_get_cached_w3_w1_permute_indices,
+        get_w2_permute_indices_with_cache,
+    )
+
+    cache: dict[tuple[str, torch.Size], torch.Tensor] = {}
+    num_experts = w13_weight.shape[0]
+
+    def allocate_block_layout(weight: torch.Tensor) -> torch.Tensor:
+        rows, byte_columns = weight[0].view(torch.uint8).shape
+        if byte_columns % _BLOCK_K:
+            raise ValueError(
+                f"weight byte columns ({byte_columns}) must be divisible by {_BLOCK_K}"
+            )
+        return torch.empty(
+            (num_experts, byte_columns // _BLOCK_K, rows, _BLOCK_K),
+            dtype=torch.uint8,
+            device=weight.device,
+        )
+
+    w13_block = allocate_block_layout(w13_weight)
+    w2_block = allocate_block_layout(w2_weight)
+
+    def copy_expert(
+        output: torch.Tensor,
+        expert: torch.Tensor,
+        row_indices: torch.Tensor,
+    ) -> None:
+        rows = expert.shape[0]
+        source = expert.view(torch.uint8).view(
+            rows, output.shape[0], _BLOCK_K
+        ).permute(1, 0, 2)
+        torch.index_select(
+            source,
+            1,
+            row_indices.to(expert.device),
+            out=output,
+        )
+
+    for expert_id in range(num_experts):
+        w13_expert = w13_weight[expert_id].view(torch.uint8)
+        w13_indices = _maybe_get_cached_w3_w1_permute_indices(
+            cache,
+            w13_expert,
+            _EPILOGUE_TILE_M,
+            is_gated_act_gemm=True,
+        )
+        # gLLM stores gate then up; TRT-LLM's fused epilogue consumes the
+        # opposite half ordering after its gated-activation row permutation.
+        w13_indices = (w13_indices + w13_expert.shape[0] // 2) % w13_expert.shape[0]
+        copy_expert(w13_block[expert_id], w13_expert, w13_indices)
+
+        w2_expert = w2_weight[expert_id].view(torch.uint8)
+        w2_indices = get_w2_permute_indices_with_cache(
+            cache,
+            w2_expert,
+            _EPILOGUE_TILE_M,
+        )
+        copy_expert(w2_block[expert_id], w2_expert, w2_indices)
+
+    return w13_block.view(torch.bfloat16), w2_block.view(torch.bfloat16)
+
+
+def trtllm_bf16_moe(
+    layer: torch.nn.Module,
+    hidden_states: torch.Tensor,
+    router_logits: torch.Tensor,
+) -> torch.Tensor:
+    """Run one finalized, unquantized TRT-LLM MoE forward."""
+    from flashinfer import RoutingMethodType
+    from flashinfer.fused_moe import trtllm_bf16_moe as flashinfer_moe
+    from flashinfer.fused_moe.core import ActivationType
+
+    routing_method = (
+        RoutingMethodType.RenormalizeNaive
+        if layer.renormalize
+        else RoutingMethodType.Default
+    )
+    local_expert_offset = layer.ep_rank * layer.local_num_experts
+    output = torch.empty_like(hidden_states)
+    result = flashinfer_moe(
+        routing_logits=router_logits,
+        routing_bias=None,
+        hidden_states=hidden_states,
+        gemm1_weights=layer.w13_weight,
+        gemm2_weights=layer.w2_weight,
+        num_experts=layer.global_num_experts,
+        top_k=layer.top_k,
+        n_group=None,
+        topk_group=None,
+        intermediate_size=layer.intermediate_size_per_partition,
+        local_expert_offset=local_expert_offset,
+        local_num_experts=layer.local_num_experts,
+        routed_scaling_factor=None,
+        routing_method_type=routing_method,
+        use_shuffled_weight=True,
+        do_finalize=True,
+        activation_type=ActivationType.Swiglu.value,
+        norm_topk_prob=layer.renormalize,
+        output=output,
+    )
+    if isinstance(result, (list, tuple)):
+        return result[0]
+    return result

--- a/gllm/layers/moe/fused_moe_triton/layer.py
+++ b/gllm/layers/moe/fused_moe_triton/layer.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import torch
+from logger import logger
 
 from gllm.distributed.parallel_state import (
     get_ep_rank,
@@ -24,6 +25,39 @@ class FusedMoEMethod(torch.nn.Module):
     def __init__(self):
         super().__init__()
         self._piecewise_workspaces = {}
+        self.backend = "triton"
+        self._weights_processed = False
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if self._weights_processed:
+            return
+        self._weights_processed = True
+
+        from gllm.layers.moe.flashinfer_trtllm import (
+            bf16_moe_support_reason,
+            convert_bf16_moe_weights,
+        )
+
+        reason = bf16_moe_support_reason(layer)
+        if reason is not None:
+            return
+
+        try:
+            w13, w2 = convert_bf16_moe_weights(
+                layer.w13_weight.data,
+                layer.w2_weight.data,
+            )
+        except Exception as exc:
+            logger.warning(
+                "FlashInfer TRT-LLM BF16 MoE weight conversion failed; "
+                "using Triton: %s",
+                exc,
+            )
+            return
+
+        layer.w13_weight.data = w13
+        layer.w2_weight.data = w2
+        self.backend = "flashinfer_trtllm_bf16"
 
     def _piecewise_workspace(
         self,
@@ -136,6 +170,12 @@ class FusedMoEMethod(torch.nn.Module):
         scoring_func: str = "softmax",
         e_score_correction_bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        self.process_weights_after_loading(layer)
+        if self.backend == "flashinfer_trtllm_bf16":
+            from gllm.layers.moe.flashinfer_trtllm import trtllm_bf16_moe
+
+            return trtllm_bf16_moe(layer, x, router_logits)
+
         topk_weights, topk_ids = select_experts(
             hidden_states=x,
             router_logits=router_logits,

--- a/gllm/layers/ops/fla/chunk.py
+++ b/gllm/layers/ops/fla/chunk.py
@@ -18,7 +18,6 @@ from gllm.layers.ops.fla.l2norm import l2norm_fwd
 from gllm.layers.ops.fla.utils import (
     SUPPRESS_LEVEL,
     autocast_custom_fwd,
-    input_guard,
 )
 
 CHUNK_SIZE = 64
@@ -75,7 +74,6 @@ def chunk_gated_delta_rule_fwd(
 class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
 
     @staticmethod
-    @input_guard
     @autocast_custom_fwd
     def forward(
         ctx,
@@ -194,6 +192,24 @@ def chunk_gated_delta_rule(
             cu_seqlens=cu_seqlens
         )
     """
+    # The autograd function used to carry ``@input_guard``, which calls
+    # ``contiguous()`` on *every* tensor argument. That is invalid for the
+    # arena-backed ``initial_state``: the recurrent kernel updates it in place,
+    # so materializing a compact temporary silently discards every state update
+    # and also erases its physical slot stride. Keep the read-only compute
+    # tensors contiguous as before, but preserve the state view itself.
+    q, k, v, g, beta = (
+        q.contiguous(),
+        k.contiguous(),
+        v.contiguous(),
+        g.contiguous(),
+        beta.contiguous(),
+    )
+    if initial_state_indices is not None:
+        initial_state_indices = initial_state_indices.contiguous()
+    if cu_seqlens is not None:
+        cu_seqlens = cu_seqlens.contiguous()
+
     assert q.dtype == k.dtype == v.dtype
     assert (
         q.dtype != torch.float32

--- a/gllm/layers/ops/fla/chunk_delta_h.py
+++ b/gllm/layers/ops/fla/chunk_delta_h.py
@@ -42,6 +42,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     initial_state_indices,
     cu_seqlens,
     chunk_offsets,
+    stride_state_token: tl.constexpr,
     T,
     H: tl.constexpr,
     Hg: tl.constexpr,
@@ -87,13 +88,21 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     if SAVE_NEW_VALUE:
         v_new += ((bos * H + i_h) * V).to(tl.int64)
     stride_v = H * V
+    # ``h`` is a compact per-chunk workspace, while ``initial_state`` may be
+    # an arena view whose logical slot stride includes padding and other
+    # layers. These strides are not interchangeable. The old compact
+    # ``H*V*K`` addressing silently read/wrote a different arena extent for
+    # every non-zero slot id.
     stride_h = H * V * K
     stride_k = Hg * K
     stride_w = H * K
 
-    index = tl.load(initial_state_indices + i_n).to(tl.int32)
-    h0 = initial_state + index * stride_h
-    ht = initial_state + index * stride_h
+    # Arena slot ids are small, but ``slot * frame_stride`` can exceed 2 Gi
+    # on large hybrid models. Promote before multiplying so pointer arithmetic
+    # cannot wrap at int32 (the decode/verify kernels already do the same).
+    index = tl.load(initial_state_indices + i_n).to(tl.int64)
+    h0 = initial_state + index * stride_state_token
+    ht = initial_state + index * stride_state_token
     if USE_INITIAL_STATE:
         h0 = h0 + i_h * V * K
     if INPLACE_UPDATE:
@@ -321,6 +330,7 @@ def chunk_gated_delta_rule_fwd_h(
         initial_state_indices=initial_state_indices,
         cu_seqlens=cu_seqlens,
         chunk_offsets=chunk_offsets,
+        stride_state_token=initial_state.stride(0),
         T=T,
         H=H,
         Hg=Hg,

--- a/gllm/layers/ops/fla/fused_recurrent.py
+++ b/gllm/layers/ops/fla/fused_recurrent.py
@@ -1140,9 +1140,9 @@ def fused_recurrent_gdn_spec(
     cu_seqlens: Optional[torch.LongTensor] = None,
     use_qk_l2norm_in_kernel: bool = False,
 ) -> torch.Tensor:
-    """Spec-decode GDN recurrence over the shared state pool.
+    """Spec-decode GDN recurrence over the shared state arena view.
 
-    ``state_source`` is the SSM temporal-state block pool ``[num_blocks, HV, V,
+    ``state_source`` is the SSM temporal-state view ``[num_blocks, HV, V,
     K]`` (in-place: h0 == ht). ``ssm_state_indices`` is the ``[nseq, 1+K]`` block
     table; each token's post-state is written to its column, the initial state
     is read from column ``num_accepted-1`` (or 0 when ``num_accepted`` is None).

--- a/gllm/layers/ops/gemma_rmsnorm.py
+++ b/gllm/layers/ops/gemma_rmsnorm.py
@@ -1,0 +1,127 @@
+"""Numerically conservative Gemma RMSNorm kernels.
+
+The reduction intentionally remains an ``aten::mean`` operation.  Besides
+being well tuned, that preserves the reduction tree used by the established
+PyTorch reference path.  The surrounding casts and pointwise operations are
+collapsed into small Triton kernels, avoiding several launches without
+changing the value presented to the reduction.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _square_to_fp32_kernel(
+    x,
+    work,
+    n_cols: tl.constexpr,
+    stride_x_row: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    cols = tl.program_id(1) * BLOCK + tl.arange(0, BLOCK)
+    mask = cols < n_cols
+    value = tl.load(x + row * stride_x_row + cols, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    tl.store(work + row * n_cols + cols, value * value, mask=mask)
+
+
+@triton.jit
+def _normalize_fp32_kernel(
+    x,
+    variance,
+    work,
+    eps: tl.constexpr,
+    n_cols: tl.constexpr,
+    stride_x_row: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    cols = tl.program_id(1) * BLOCK + tl.arange(0, BLOCK)
+    mask = cols < n_cols
+    value = tl.load(x + row * stride_x_row + cols, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    var = tl.load(variance + row).to(tl.float32)
+    normalized = value * tl.rsqrt(var + eps)
+    tl.store(work + row * n_cols + cols, normalized, mask=mask)
+
+
+@triton.jit
+def _gemma_scale_kernel(
+    work,
+    weight,
+    out,
+    n_cols: tl.constexpr,
+    stride_out_row: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    cols = tl.program_id(1) * BLOCK + tl.arange(0, BLOCK)
+    mask = cols < n_cols
+    normalized = tl.load(work + row * n_cols + cols, mask=mask, other=0.0)
+    scale = tl.load(weight + cols, mask=mask, other=0.0).to(tl.float32) + 1.0
+    tl.store(
+        out + row * stride_out_row + cols,
+        normalized * scale,
+        mask=mask,
+    )
+
+
+def gemma_rms_norm_reference_reduction(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    epsilon: float,
+) -> None:
+    """Gemma RMSNorm with the PyTorch-reference FP32 reduction order.
+
+    Inputs may have any leading dimensions, but the feature dimension must be
+    contiguous.  This is the same layout contract as the other RMSNorm
+    backends used by gLLM.
+    """
+    if input.shape != out.shape:
+        raise ValueError(f"input/out shape mismatch: {input.shape} vs {out.shape}")
+    if input.shape[-1] != weight.numel():
+        raise ValueError(f"input/weight shape mismatch: {input.shape} vs {weight.shape}")
+    if input.stride(-1) != 1 or out.stride(-1) != 1:
+        raise ValueError("Gemma RMSNorm requires a contiguous feature dimension")
+
+    n_cols = input.shape[-1]
+    n_rows = input.numel() // n_cols
+    input_2d = input.reshape(n_rows, n_cols)
+    out_2d = out.reshape(n_rows, n_cols)
+    work = torch.empty((n_rows, n_cols), dtype=torch.float32, device=input.device)
+    block = min(1024, triton.next_power_of_2(n_cols))
+    grid = (n_rows, triton.cdiv(n_cols, block))
+
+    _square_to_fp32_kernel[grid](
+        input_2d,
+        work,
+        n_cols,
+        input_2d.stride(0),
+        BLOCK=block,
+    )
+    # Keep this reduction as aten::mean: model correctness was established
+    # against its FP32 reduction tree on SM100.
+    variance = work.mean(dim=-1, keepdim=True)
+    _normalize_fp32_kernel[grid](
+        input_2d,
+        variance,
+        work,
+        epsilon,
+        n_cols,
+        input_2d.stride(0),
+        BLOCK=block,
+    )
+    _gemma_scale_kernel[grid](
+        work,
+        weight,
+        out_2d,
+        n_cols,
+        out_2d.stride(0),
+        BLOCK=block,
+    )

--- a/gllm/layers/ops/triton_decode_attention.py
+++ b/gllm/layers/ops/triton_decode_attention.py
@@ -51,8 +51,10 @@ def _fwd_kernel_stage1(
     stride_req_to_tokens_b,
     stride_qbs,
     stride_qh,
+    stride_buf_kblock,
     stride_buf_kbs,
     stride_buf_kh,
+    stride_buf_vblock,
     stride_buf_vbs,
     stride_buf_vh,
     stride_mid_ob,
@@ -102,9 +104,10 @@ def _fwd_kernel_stage1(
                 mask=offs_n < split_kv_end,
                 other=0,
             )
-            kv_loc = kv_page_number * PAGE_SIZE + offs_n % PAGE_SIZE
+            kv_token = offs_n % PAGE_SIZE
             offs_buf_k = (
-                kv_loc[:, None] * stride_buf_kbs
+                kv_page_number[:, None] * stride_buf_kblock
+                + kv_token[:, None] * stride_buf_kbs
                 + cur_kv_head * stride_buf_kh
                 + offs_d[None, :]
             )
@@ -122,7 +125,8 @@ def _fwd_kernel_stage1(
             qk = tl.where(offs_n < split_kv_end, qk, float("-inf"))
 
             offs_buf_v = (
-                kv_loc[:, None] * stride_buf_vbs
+                kv_page_number[:, None] * stride_buf_vblock
+                + kv_token[:, None] * stride_buf_vbs
                 + cur_kv_head * stride_buf_vh
                 + offs_dv[None, :]
             )
@@ -208,8 +212,10 @@ def _decode_att_m_fwd(
         Req_to_tokens.stride(0),
         q.stride(0),
         q.stride(1),
+        k_buffer.stride(0),
         k_buffer.stride(-3),  # Assume (..., PAGE_SIZE, NUM_HEADS, HEAD_DIM)
         k_buffer.stride(-2),  # Assume (..., PAGE_SIZE, NUM_HEADS, HEAD_DIM)
+        v_buffer.stride(0),
         v_buffer.stride(-3),  # Assume (..., PAGE_SIZE, NUM_HEADS, HEAD_DIM)
         v_buffer.stride(-2),  # Assume (..., PAGE_SIZE, NUM_HEADS, HEAD_DIM)
         att_out.stride(0),
@@ -241,8 +247,10 @@ def _fwd_grouped_kernel_stage1(
     stride_req_to_tokens_b,
     stride_qbs,
     stride_qh,
+    stride_buf_kblock,
     stride_buf_kbs,
     stride_buf_kh,
+    stride_buf_vblock,
     stride_buf_vbs,
     stride_buf_vh,
     stride_mid_ob,
@@ -312,9 +320,10 @@ def _fwd_grouped_kernel_stage1(
                 mask=offs_n < split_kv_end,
                 other=0,
             )
-            kv_loc = kv_page_number * PAGE_SIZE + offs_n % PAGE_SIZE
+            kv_token = offs_n % PAGE_SIZE
             offs_buf_k = (
-                kv_loc[None, :] * stride_buf_kbs
+                kv_page_number[None, :] * stride_buf_kblock
+                + kv_token[None, :] * stride_buf_kbs
                 + cur_kv_head * stride_buf_kh
                 + offs_d[:, None]
             )
@@ -326,7 +335,8 @@ def _fwd_grouped_kernel_stage1(
             qk = tl.dot(q, k.to(q.dtype))
             if BLOCK_DPE > 0:
                 offs_buf_kpe = (
-                    kv_loc[None, :] * stride_buf_kbs
+                    kv_page_number[None, :] * stride_buf_kblock
+                    + kv_token[None, :] * stride_buf_kbs
                     + cur_kv_head * stride_buf_kh
                     + offs_dpe[:, None]
                 )
@@ -346,7 +356,8 @@ def _fwd_grouped_kernel_stage1(
             )
 
             offs_buf_v = (
-                kv_loc[:, None] * stride_buf_vbs
+                kv_page_number[:, None] * stride_buf_vblock
+                + kv_token[:, None] * stride_buf_vbs
                 + cur_kv_head * stride_buf_vh
                 + offs_dv[None, :]
             )
@@ -444,8 +455,10 @@ def _decode_grouped_att_m_fwd(
         Req_to_tokens.stride(0),
         q.stride(0),
         q.stride(1),
+        k_buffer.stride(0),
         k_buffer.stride(-3),  # Assume (..., PAGE_SIZE, NUM_HEADS, HEAD_DIM)
         k_buffer.stride(-2),  # Assume (..., PAGE_SIZE, NUM_HEADS, HEAD_DIM)
+        v_buffer.stride(0),
         v_buffer.stride(-3),  # Assume (..., PAGE_SIZE, NUM_HEADS, HEAD_DIM)
         v_buffer.stride(-2),  # Assume (..., PAGE_SIZE, NUM_HEADS, HEAD_DIM)
         att_out.stride(0),

--- a/gllm/models/qwen3_5.py
+++ b/gllm/models/qwen3_5.py
@@ -25,7 +25,7 @@ Architectural cheat-sheet (Qwen3.5-0.8B config):
       out     = out_proj(norm)
 
   ``conv_state`` (Cin, kernel) and ``ssm_state`` (Nv, Hk, Hv) live in the
-  :class:`gllm.runtime.memory_manager.SSMSegment` working pool; the slot id is
+  :class:`gllm.runtime.memory_manager.SSMSegment` arena view; the slot id is
   ``sequence.ssm_state_slot`` (filled by the scheduler and pushed to GPU
   by :meth:`InputData._cal_ssm_metadata`).
 * Some checkpoints ship an ``mtp.*`` multi-token-prediction head for
@@ -190,7 +190,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
     ``A_log``, ``dt_bias``, ``norm``, ``out_proj``. The actual recurrence
     runs on the vendored FLA Triton kernels at
     :mod:`gllm.layers.ops.fla`. State lives in the
-    :class:`gllm.runtime.memory_manager.SSMSegment` working pool, addressed via
+    :class:`gllm.runtime.memory_manager.SSMSegment` arena view, addressed via
     ``input_data.get_ssm_state_slot_per_seq()``.
     """
 
@@ -306,7 +306,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         """Return the per-layer ``conv_state`` and ``ssm_state`` views.
 
         ``SSMSegment`` packs all linear-attention layers into a single
-        ``[L, working_pool_size, ...]`` tensor (slot 0 == CUDA-graph dummy);
+        ``[L, num_state_slots, ...]`` arena view (slot 0 == CUDA-graph dummy);
         the runtime-only ``self.ssm_layer_id`` selects this layer's slice.
         """
         seg = input_data.memory_manager.ssm_segment
@@ -322,7 +322,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         ssm_state_working: torch.Tensor,
         row_start: int = 0,
     ) -> None:
-        """Copy this layer's working state into the snapshot pool slots
+        """Copy this layer's working state into reclaimable snapshot slots
         designated by ``input_data.get_ssm_snapshot_write_slot_per_seq``.
 
         Indexed copy is vectorized via ``index_select`` + ``index_copy_``
@@ -365,17 +365,23 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         src_idx = src_slots.index_select(0, valid_idx).to(torch.long)
         dst_idx = snap_targets.index_select(0, valid_idx).to(torch.long)
 
-        # Capture = copy this layer's working block -> the page's cached block,
-        # both in the SAME shared pool (``conv_state_working`` /
+        # Capture = copy this layer's working entry -> the page's cached entry;
+        # both address the same arena view (``conv_state_working`` /
         # ``ssm_state_working`` are ``seg.conv_state[ssm_layer_id]`` /
-        # ``seg.temporal_state[ssm_layer_id]``). ``src_idx`` (live rolling block)
-        # and ``dst_idx`` (cached block) are distinct block ids -> no alias.
+        # ``seg.temporal_state[ssm_layer_id]``). ``src_idx`` (live rolling entry)
+        # and ``dst_idx`` (cached entry) have distinct live ownership -> no alias.
         conv_state_working.index_copy_(
             0, dst_idx, conv_state_working.index_select(0, src_idx)
         )
         ssm_state_working.index_copy_(
             0, dst_idx, ssm_state_working.index_select(0, src_idx)
         )
+        # CPU metadata for overlap batches is speculative. Make the snapshot
+        # visible to prefix lookup only after the actual device copies have
+        # been enqueued. The worker cannot schedule the next batch until this
+        # Python forward returns, and all recurrent-state work shares the same
+        # forward stream, so publication here closes the zero-snapshot window.
+        input_data.mark_ssm_snapshot_writes_enqueued()
 
     def _is_decode_batch(self, input_data: InputData) -> bool:
         """All-decode batches have exactly one query token per sequence and
@@ -438,8 +444,8 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         state block table; column 0 holds its committed (pre-x1) rolling state.
         We run the recurrent GDN kernel token-by-token starting from column 0 and
         write each token ``t``'s post-state into column ``t`` of the block table
-        (both temporal state and conv window). The blocks are the SAME shared
-        pool the rolling state lives in -- no separate intermediate buffer. After
+        (both temporal state and conv window). The entries use the same arena
+        view as rolling state -- no separate intermediate buffer. After
         sampling, the accept step copies the committed column (``na``) back to
         column 0 (see ``model_runner._mtp_decode``), so the plain decode/snapshot
         paths keep reading column 0.
@@ -485,7 +491,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
 
         # Temporal state: recurrent kernel reads column ``num_accepted-1`` and
         # writes each verify token t's post-state into column t (in the shared
-        # ``ssm_state`` pool, addressed by the 2D block table).
+        # ``ssm_state`` arena view, addressed by the 2D block table).
         core_attn_out = fused_recurrent_gdn_spec(
             A_log=self.A_log,
             a=a,
@@ -628,13 +634,16 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         q, k, v, z, b, a = self._split_qkvzba(qkvz, ba)
 
         seq_len = hidden_states.shape[0]
-        # Flatten per-head dims into one channel dim for ``causal_conv1d_*``;
-        # the kernels expect ``mixed_qkv`` as ``[T, C_in]`` (prefill) or
-        # ``[B, C_in]`` (decode).
-        mixed_qkv = torch.cat(
-            (q.reshape(seq_len, -1), k.reshape(seq_len, -1), v.reshape(seq_len, -1)),
-            dim=-1,
+        # ``in_proj_qkvz`` already lays out Q, K and V as one adjacent prefix.
+        # Keep that strided view instead of materializing the same bytes with a
+        # per-layer ``cat``.  All causal-conv paths consume explicit strides
+        # and produce their own contiguous output, so the trailing Z columns
+        # in the projection's physical row stride are harmless.
+        qkv_width = (
+            2 * (self.key_dim // get_tp_size())
+            + self.value_dim // get_tp_size()
         )
+        mixed_qkv = qkvz[:, :qkv_width]
         conv_state, ssm_state = self._ssm_state_tensors(input_data)
         cache_indices = input_data.get_ssm_state_slot_per_seq()
         has_initial_state = input_data.get_has_initial_state_per_seq()
@@ -784,9 +793,9 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                 query_start_loc,
                 getattr(input_data, "seq_lens_cpu", None),
             )
-            # Phase G.3: persist the just-computed state into the snapshot
-            # pool for seqs whose chunk ended on a page boundary that
-            # ``PrefixSegment`` pre-reserved a snapshot slot for. This is
+            # Phase G.3: persist the just-computed state into a snapshot arena
+            # entry for seqs whose chunk ended on an eligible page boundary.
+            # ``InputData`` borrows the entry lazily for this forward. This is
             # how cross-seq prefix-cache hits later restore the GDN
             # recurrent state into a fresh working slot. ``-1`` slots are a
             # no-op so non-PrefixSegment runs / non-cacheable boundaries
@@ -1015,7 +1024,7 @@ class Qwen3_5Model(nn.Module):
 
     ``self.num_kv_layers`` and ``self.ssm_layer_global_ids`` are then read by
     ``model_runner.init`` and surfaced to :class:`MemoryManager` so the KV
-    page budget and the SSM pool match the model's real shape.
+    page and recurrent-state arena layouts match the model's real shape.
     """
 
     def __init__(self, config, decoder_layer_type=None):
@@ -1044,7 +1053,7 @@ class Qwen3_5Model(nn.Module):
         # Build dense KV / SSM layer indices for the layers that belong to
         # this pipeline rank. The model only allocates the slice
         # ``[start_layer, end_layer)`` so the local indices reset at the PP
-        # boundary — KV cache and SSM pool are also sized per-rank.
+        # boundary — KV and recurrent cache views are also sized per-rank.
         self._layer_types: List[str] = []
         self._kv_layer_ids: List[Optional[int]] = []
         self._ssm_layer_ids: List[Optional[int]] = []
@@ -1086,7 +1095,7 @@ class Qwen3_5Model(nn.Module):
         self.num_kv_layers = kv_counter
         self.num_ssm_layers = ssm_counter
         # Global linear-attn layer indices (for diagnostics / config); the
-        # PrefixSegment uses a dense pool so we just need the count.
+        # SSMSegment uses a dense layer axis, so we just need the count.
         self.ssm_layer_global_ids = [
             self.start_layer + i
             for i, lt in enumerate(self._layer_types)

--- a/gllm/runtime/cache_arena.py
+++ b/gllm/runtime/cache_arena.py
@@ -1,0 +1,618 @@
+"""Extensible GPU cache arena with typed, strided tensor views.
+
+The arena owns one byte tensor and divides it into fixed-size physical pages.
+Cache consumers register a *type* describing the number of physical pages in
+one logical slot.  Types can have different slot sizes and can reuse the same
+bytes at different times; KV and recurrent state are merely the first two
+users of this mechanism.
+
+Every type uses an aligned fixed-stride slot grid.  That gives kernels a stable
+base pointer and stride (required by CUDA Graph) while the allocator decides
+which slots are physically live.  An eviction callback lets a cache type drop
+unpinned metadata when another type claims overlapping bytes.
+"""
+
+import heapq
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple
+
+import torch
+
+from gllm.utils import get_dtype_bytes
+
+
+def _numel(shape) -> int:
+    value = 1
+    for dim in shape:
+        value *= int(dim)
+    return value
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return (value + alignment - 1) // alignment * alignment
+
+
+@dataclass(frozen=True)
+class CacheTensorLayout:
+    """One tensor bank stored inside every logical cache entry."""
+
+    name: str
+    dtype: torch.dtype
+    shape: Tuple[int, ...]
+
+    def __post_init__(self):
+        object.__setattr__(self, "shape", tuple(int(dim) for dim in self.shape))
+        if not self.name or any(dim <= 0 for dim in self.shape):
+            raise ValueError((self.name, self.shape))
+
+    @property
+    def nbytes(self) -> int:
+        return _numel(self.shape) * get_dtype_bytes(self.dtype)
+
+
+@dataclass(frozen=True)
+class CacheLayout:
+    """Complete layout of one registered logical cache slot.
+
+    A cache can contain several banks that share one lifetime and page id. For
+    example, explicit attention registers K and V banks, while DSA registers
+    its MLA latent plus BF16 and FP8 index banks as one cache entry.
+    """
+
+    name: str
+    tensors: Tuple[CacheTensorLayout, ...]
+    prefer_high: bool = False
+
+    def __post_init__(self):
+        object.__setattr__(self, "tensors", tuple(self.tensors))
+        names = [tensor.name for tensor in self.tensors]
+        if not self.name or not names or len(names) != len(set(names)):
+            raise ValueError((self.name, names))
+
+    def packed_offsets(self) -> Dict[str, int]:
+        offsets: Dict[str, int] = {}
+        offset = 0
+        for tensor in self.tensors:
+            offset = _align_up(offset, get_dtype_bytes(tensor.dtype))
+            offsets[tensor.name] = offset
+            offset += tensor.nbytes
+        return offsets
+
+    @property
+    def entry_bytes(self) -> int:
+        offsets = self.packed_offsets()
+        # Keep every physical entry suitable for a later registered cache with
+        # wider scalar types. This also makes entry strides friendly to vector
+        # loads without imposing alignment rules on individual consumers.
+        alignment = max(16, *(get_dtype_bytes(tensor.dtype) for tensor in self.tensors))
+        last = self.tensors[-1]
+        return _align_up(offsets[last.name] + last.nbytes, alignment)
+
+
+@dataclass
+class ArenaCacheType:
+    """One logical cache layout registered in a :class:`CacheArena`."""
+
+    name: str
+    entry_bytes: int
+    pages_per_slot: int
+    num_slots: int
+    prefer_high: bool = False
+    free_slots: Set[int] = field(default_factory=set)
+    free_heap: List[int] = field(default_factory=list)
+    live_slots: Set[int] = field(default_factory=set)
+    # Number of physical pages in each logical slot currently owned by any
+    # cache type. Maintaining this incrementally makes the allocator's hot
+    # ``is extent free?`` query O(1), independent of entry size.
+    occupied_pages: List[int] = field(default_factory=list)
+    evictor: Optional[Callable[[int], None]] = None
+    reclaimer: Optional[Callable[[], bool]] = None
+
+    def heap_key(self, slot: int) -> int:
+        return -slot if self.prefer_high else slot
+
+    def add_free(self, slot: int) -> None:
+        if slot in self.free_slots:
+            return
+        self.free_slots.add(slot)
+        heapq.heappush(self.free_heap, self.heap_key(slot))
+
+    def discard_free(self, slot: int) -> None:
+        self.free_slots.discard(slot)
+
+    def take_free(self) -> Optional[int]:
+        while self.free_heap:
+            key = heapq.heappop(self.free_heap)
+            slot = -key if self.prefer_high else key
+            if slot in self.free_slots:
+                self.free_slots.remove(slot)
+                return slot
+        return None
+
+
+class CacheArenaAllocator:
+    """Generic aligned-extent allocator over physical arena pages.
+
+    Allocation is expressed in logical slot ids, not byte pointers.  A slot's
+    physical extent is ``[slot * pages_per_slot, (slot + 1) * pages_per_slot)``.
+    Different cache types therefore expose independent logical id spaces while
+    sharing one physical ownership map.
+    """
+
+    def __init__(self, num_physical_pages: int):
+        if num_physical_pages <= 0:
+            raise ValueError(num_physical_pages)
+        self.num_physical_pages = int(num_physical_pages)
+        self._owners: List[Optional[Tuple[str, int]]] = [None] * self.num_physical_pages
+        self._types: Dict[str, ArenaCacheType] = {}
+        self._used_physical_pages = 0
+
+    def register_type(
+        self,
+        name: str,
+        entry_bytes: int,
+        physical_page_bytes: int,
+        *,
+        prefer_high: bool = False,
+    ) -> ArenaCacheType:
+        if name in self._types:
+            raise ValueError(f"arena cache type {name!r} already exists")
+        if entry_bytes <= 0:
+            raise ValueError(entry_bytes)
+        pages = (int(entry_bytes) + physical_page_bytes - 1) // physical_page_bytes
+        cache_type = ArenaCacheType(
+            name=name,
+            entry_bytes=int(entry_bytes),
+            pages_per_slot=pages,
+            num_slots=self.num_physical_pages // pages,
+            prefer_high=prefer_high,
+            occupied_pages=[0] * (self.num_physical_pages // pages),
+        )
+        self._types[name] = cache_type
+        # Types are normally registered before the first claim. Populate from
+        # the owner map as a correctness-preserving fallback for dynamically
+        # registered cache shapes.
+        for slot in range(cache_type.num_slots):
+            start, end = self._extent(cache_type, slot)
+            occupied = sum(owner is not None for owner in self._owners[start:end])
+            cache_type.occupied_pages[slot] = occupied
+            if occupied == 0:
+                cache_type.add_free(slot)
+        return cache_type
+
+    def cache_type(self, name: str) -> ArenaCacheType:
+        try:
+            return self._types[name]
+        except KeyError as exc:
+            raise KeyError(f"unknown arena cache type {name!r}") from exc
+
+    @property
+    def cache_type_names(self) -> Tuple[str, ...]:
+        return tuple(self._types)
+
+    def set_evictor(self, name: str, callback: Callable[[int], None]) -> None:
+        self.cache_type(name).evictor = callback
+
+    def set_reclaimer(self, name: str, callback: Callable[[], bool]) -> None:
+        """Register pressure-driven reclamation for an evictable cache type."""
+        self.cache_type(name).reclaimer = callback
+
+    def _reclaim_for(self, request: ArenaCacheType, count: int) -> bool:
+        while len(request.free_slots) < count:
+            progressed = False
+            for donor in self._types.values():
+                # Replacing one entry with another entry of the same cache type
+                # only churns metadata and cannot increase its free capacity.
+                if donor.name == request.name or donor.reclaimer is None:
+                    continue
+                before = self._used_physical_pages
+                if donor.reclaimer():
+                    progressed = True
+                    if self._used_physical_pages >= before:
+                        raise RuntimeError(
+                            f"arena reclaimer {donor.name!r} freed no physical pages"
+                        )
+                    if len(request.free_slots) >= count:
+                        return True
+            if not progressed:
+                return False
+        return True
+
+    @staticmethod
+    def _extent(cache_type: ArenaCacheType, slot: int) -> Tuple[int, int]:
+        if not 0 <= slot < cache_type.num_slots:
+            raise IndexError(
+                f"{cache_type.name} slot {slot} outside [0, {cache_type.num_slots})"
+            )
+        start = slot * cache_type.pages_per_slot
+        return start, start + cache_type.pages_per_slot
+
+    def _is_extent_free(self, cache_type: ArenaCacheType, slot: int) -> bool:
+        if not 0 <= slot < cache_type.num_slots:
+            self._extent(cache_type, slot)  # raise the canonical IndexError
+        return cache_type.occupied_pages[slot] == 0
+
+    def _overlapping_slots(
+        self, cache_type: ArenaCacheType, start: int, end: int
+    ) -> range:
+        span = cache_type.pages_per_slot
+        first = start // span
+        last = min(cache_type.num_slots - 1, (end - 1) // span)
+        return range(first, last + 1)
+
+    def _update_candidates(self, start: int, end: int, delta: int) -> None:
+        """Apply one physical ownership transition to every typed slot grid."""
+        if delta not in (-1, 1):
+            raise ValueError(delta)
+        for cache_type in self._types.values():
+            for slot in self._overlapping_slots(cache_type, start, end):
+                slot_start, slot_end = self._extent(cache_type, slot)
+                overlap = min(end, slot_end) - max(start, slot_start)
+                occupied = cache_type.occupied_pages[slot] + delta * overlap
+                if not 0 <= occupied <= cache_type.pages_per_slot:
+                    raise RuntimeError(
+                        f"arena occupancy index is inconsistent for "
+                        f"{cache_type.name} slot {slot}: {occupied}"
+                    )
+                cache_type.occupied_pages[slot] = occupied
+                if occupied == 0:
+                    cache_type.add_free(slot)
+                else:
+                    cache_type.discard_free(slot)
+
+    def _claim(self, cache_type: ArenaCacheType, slot: int) -> None:
+        self._claim_many(cache_type, [slot])
+
+    def _claim_many(self, cache_type: ArenaCacheType, slots: Iterable[int]) -> None:
+        """Claim a cohort and coalesce adjacent candidate-index updates."""
+        slot_list = [int(slot) for slot in slots]
+        if len(set(slot_list)) != len(slot_list):
+            raise RuntimeError(
+                f"duplicate {cache_type.name} slots in one claim: {slot_list}"
+            )
+        extents = []
+        for slot in slot_list:
+            start, end = self._extent(cache_type, slot)
+            if not self._is_extent_free(cache_type, slot):
+                raise RuntimeError(
+                    f"{cache_type.name} slot {slot} is not physically free"
+                )
+            extents.append((start, end, slot))
+
+        for start, end, slot in extents:
+            owner = (cache_type.name, slot)
+            self._owners[start:end] = [owner] * (end - start)
+            cache_type.live_slots.add(slot)
+            self._used_physical_pages += end - start
+        merged = []
+        for start, end, _ in sorted(extents):
+            if merged and start == merged[-1][1]:
+                merged[-1] = (merged[-1][0], end)
+            else:
+                merged.append((start, end))
+        for start, end in merged:
+            self._update_candidates(start, end, 1)
+
+    def _evict_stale_views(
+        self,
+        allocations: Iterable[Tuple[str, int]],
+        *,
+        preserved: Optional[Set[Tuple[str, int]]] = None,
+    ) -> None:
+        # Claims are already visible, so callbacks that free some other cache
+        # entry cannot accidentally reselect the just-claimed extent.
+        notified: Set[Tuple[str, int]] = set()
+        for name, slot in allocations:
+            source = self.cache_type(name)
+            start, end = self._extent(source, slot)
+            for cache_type in self._types.values():
+                if cache_type.evictor is None:
+                    continue
+                for stale_slot in self._overlapping_slots(cache_type, start, end):
+                    key = (cache_type.name, stale_slot)
+                    if key in notified or (preserved is not None and key in preserved):
+                        continue
+                    notified.add(key)
+                    cache_type.evictor(stale_slot)
+
+    def allocate(
+        self,
+        name: str,
+        count: int = 1,
+        *,
+        slot: Optional[int] = None,
+        retain: bool = False,
+    ) -> Optional[List[int]]:
+        """Atomically claim logical slots.
+
+        ``slot`` is used for prefix-cache retention. If that exact slot is
+        already owned by the same cache type, physical ownership is unchanged;
+        the caller maintains its own logical reference count.
+        """
+        cache_type = self.cache_type(name)
+        count = int(count)
+        if count < 0 or (slot is not None and count != 1) or (retain and slot is None):
+            raise ValueError((count, slot, retain))
+        if count == 0:
+            return []
+
+        if slot is not None:
+            start, end = self._extent(cache_type, int(slot))
+            owners = set(self._owners[start:end])
+            if owners == {(name, int(slot))}:
+                if retain:
+                    return [int(slot)]
+                raise RuntimeError(f"{name} slot {slot} is already live")
+            if owners != {None}:
+                return None
+            cache_type.discard_free(int(slot))
+            selected = [int(slot)]
+            retain_existing_contents = retain
+        else:
+            if len(cache_type.free_slots) < count and not self._reclaim_for(
+                cache_type, count
+            ):
+                return None
+            selected = []
+            for _ in range(count):
+                candidate = cache_type.take_free()
+                if candidate is None:
+                    raise RuntimeError("arena free-slot index is inconsistent")
+                selected.append(candidate)
+            retain_existing_contents = False
+
+        self._claim_many(cache_type, selected)
+        preserved = {(name, selected[0])} if retain_existing_contents else None
+        self._evict_stale_views(
+            ((name, selected_slot) for selected_slot in selected),
+            preserved=preserved,
+        )
+        return selected
+
+    def free(self, name: str, slots: Iterable[int]) -> None:
+        cache_type = self.cache_type(name)
+        slot_list = [int(value) for value in slots]
+        if len(set(slot_list)) != len(slot_list):
+            raise RuntimeError(f"duplicate {name} slots in one free: {slot_list}")
+        extents = []
+        for slot in slot_list:
+            start, end = self._extent(cache_type, slot)
+            expected = (name, slot)
+            if any(owner != expected for owner in self._owners[start:end]):
+                raise RuntimeError(f"{name} slot {slot} is not live")
+            extents.append((start, end, slot))
+
+        # Release metadata atomically, then coalesce adjacent physical ranges.
+        # MTP block tables are allocated as neighboring arena entries; updating
+        # every overlapping cache grid once for the combined range avoids
+        # repeating the generic candidate walk for each checkpoint column.
+        for start, end, slot in extents:
+            self._owners[start:end] = [None] * (end - start)
+            cache_type.live_slots.remove(slot)
+            self._used_physical_pages -= end - start
+        merged = []
+        for start, end, _ in sorted(extents):
+            if merged and start == merged[-1][1]:
+                merged[-1] = (merged[-1][0], end)
+            else:
+                merged.append((start, end))
+        for start, end in merged:
+            self._update_candidates(start, end, -1)
+
+    def is_free(self, name: str, slot: int) -> bool:
+        cache_type = self.cache_type(name)
+        return self._is_extent_free(cache_type, int(slot))
+
+    def num_free_slots(self, name: str) -> int:
+        return len(self.cache_type(name).free_slots)
+
+    def num_available_slots(self, name: str) -> int:
+        """Free slots plus pressure-reclaimable capacity (admission estimate)."""
+        request = self.cache_type(name)
+        reclaimable_pages = sum(
+            len(cache_type.live_slots) * cache_type.pages_per_slot
+            for cache_type in self._types.values()
+            if cache_type.name != name and cache_type.reclaimer is not None
+        )
+        return min(
+            request.num_slots,
+            len(request.free_slots) + reclaimable_pages // request.pages_per_slot,
+        )
+
+    @property
+    def num_used_physical_pages(self) -> int:
+        return self._used_physical_pages
+
+
+class RegisteredCache:
+    """A registered cache layout and its stable tensor views."""
+
+    def __init__(
+        self,
+        arena: "CacheArena",
+        layout: CacheLayout,
+        cache_type: ArenaCacheType,
+    ):
+        self.arena = arena
+        self.layout = layout
+        self.cache_type = cache_type
+        offsets = layout.packed_offsets()
+        self._tensors = {
+            tensor.name: arena.entry_view(
+                layout.name,
+                tensor.dtype,
+                tensor.shape,
+                entry_offset_bytes=offsets[tensor.name],
+            )
+            for tensor in layout.tensors
+        }
+
+    @property
+    def name(self) -> str:
+        return self.layout.name
+
+    @property
+    def num_slots(self) -> int:
+        return self.cache_type.num_slots
+
+    @property
+    def entry_bytes(self) -> int:
+        return self.layout.entry_bytes
+
+    def tensor(self, name: str) -> torch.Tensor:
+        try:
+            return self._tensors[name]
+        except KeyError as exc:
+            raise KeyError(f"cache {self.name!r} has no tensor {name!r}") from exc
+
+    def slot_allocator(self) -> "ArenaSlotAllocator":
+        return ArenaSlotAllocator(self.arena, self.name)
+
+
+class CacheArena:
+    """One GPU storage allocation plus its generic physical-page allocator."""
+
+    def __init__(self, backing: torch.Tensor, physical_page_bytes: int):
+        if backing.dtype != torch.uint8 or not backing.is_contiguous():
+            raise ValueError("cache arena backing must be contiguous uint8")
+        if physical_page_bytes <= 0 or backing.numel() % physical_page_bytes:
+            raise ValueError((backing.numel(), physical_page_bytes))
+        self.backing = backing
+        self.physical_page_bytes = int(physical_page_bytes)
+        self.allocator = CacheArenaAllocator(
+            backing.numel() // self.physical_page_bytes
+        )
+        self._registered_caches: Dict[str, RegisteredCache] = {}
+
+    def register_cache(self, layout: CacheLayout) -> RegisteredCache:
+        """Register a multi-bank cache and materialize all of its views."""
+        if layout.name in self._registered_caches:
+            raise ValueError(f"arena cache {layout.name!r} already exists")
+        cache_type = self.register_cache_type(
+            layout.name,
+            layout.entry_bytes,
+            prefer_high=layout.prefer_high,
+        )
+        cache = RegisteredCache(self, layout, cache_type)
+        self._registered_caches[layout.name] = cache
+        return cache
+
+    def cache(self, name: str) -> RegisteredCache:
+        try:
+            return self._registered_caches[name]
+        except KeyError as exc:
+            raise KeyError(f"unknown registered cache {name!r}") from exc
+
+    def register_cache_type(
+        self,
+        name: str,
+        entry_bytes: int,
+        *,
+        prefer_high: bool = False,
+    ) -> ArenaCacheType:
+        return self.allocator.register_type(
+            name,
+            entry_bytes,
+            self.physical_page_bytes,
+            prefer_high=prefer_high,
+        )
+
+    def entry_view(
+        self,
+        name: str,
+        dtype: torch.dtype,
+        trailing_shape,
+        *,
+        entry_offset_bytes: int = 0,
+    ) -> torch.Tensor:
+        """Return ``[num_slots, *trailing_shape]`` over a cache-type grid."""
+        cache_type = self.allocator.cache_type(name)
+        item_size = get_dtype_bytes(dtype)
+        if entry_offset_bytes % item_size:
+            raise ValueError((entry_offset_bytes, dtype))
+        numel = 1
+        for dim in trailing_shape:
+            numel *= int(dim)
+        if entry_offset_bytes + numel * item_size > cache_type.entry_bytes:
+            raise ValueError(
+                f"view exceeds {name} entry: offset={entry_offset_bytes}, "
+                f"bytes={numel * item_size}, entry={cache_type.entry_bytes}"
+            )
+        inner_stride = []
+        running = 1
+        for dim in reversed(tuple(trailing_shape)):
+            inner_stride.append(running)
+            running *= int(dim)
+        return self.strided_view(
+            dtype,
+            (cache_type.num_slots, *tuple(trailing_shape)),
+            (
+                cache_type.pages_per_slot * self.physical_page_bytes // item_size,
+                *reversed(inner_stride),
+            ),
+            storage_offset_bytes=entry_offset_bytes,
+        )
+
+    def strided_view(
+        self,
+        dtype: torch.dtype,
+        shape,
+        stride,
+        *,
+        storage_offset_bytes: int = 0,
+    ) -> torch.Tensor:
+        """Build an arbitrary stable tensor layout over the arena storage.
+
+        ``entry_view`` covers the common slot-major layout. This lower-level
+        primitive supports cache shapes with additional leading axes (for
+        example layer-major recurrent state) without teaching the allocator
+        about those axes.
+        """
+        item_size = get_dtype_bytes(dtype)
+        if storage_offset_bytes % item_size:
+            raise ValueError((storage_offset_bytes, dtype))
+        return torch.as_strided(
+            self.backing.view(dtype),
+            size=tuple(shape),
+            stride=tuple(stride),
+            storage_offset=storage_offset_bytes // item_size,
+        )
+
+
+class ArenaSlotAllocator:
+    """``IDAllocator``-compatible facade for one registered cache type."""
+
+    def __init__(self, arena: CacheArena, cache_type: str):
+        self.arena = arena
+        self.cache_type = cache_type
+        self.size = arena.allocator.cache_type(cache_type).num_slots
+
+    def allocate(self, id: Optional[int] = None):
+        slots = self.arena.allocator.allocate(
+            self.cache_type, slot=id, retain=id is not None
+        )
+        if slots is None:
+            raise RuntimeError(f"no free {self.cache_type} arena slot")
+        return slots[0]
+
+    def free(self, id: int):
+        self.arena.allocator.free(self.cache_type, [id])
+
+    def free_many(self, ids: Iterable[int]) -> None:
+        """Return a cohort in one allocator transaction.
+
+        Sequence teardown commonly releases a contiguous KV page table.  The
+        arena allocator can coalesce those physical extents before updating
+        every registered cache-type grid, which is lost when callers invoke
+        ``free`` once per page.
+        """
+        self.arena.allocator.free(self.cache_type, ids)
+
+    def is_free(self, id: int) -> bool:
+        return self.arena.allocator.is_free(self.cache_type, id)
+
+    def get_num_used_ids(self):
+        return self.arena.allocator.num_used_physical_pages
+
+    def get_num_free_ids(self):
+        return self.arena.allocator.num_available_slots(self.cache_type)

--- a/gllm/runtime/input_data.py
+++ b/gllm/runtime/input_data.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 import numpy as np
 import torch
 
+from gllm.distributed.parallel_state import get_pp_size
 from gllm.runtime.forward_metadata import (
     ForwardMetadataPlan,
     MetadataMaterialization,
@@ -111,7 +112,7 @@ class InputData:
                 self.has_initial_state_per_seq = torch.zeros(
                     max_running_seqs, dtype=torch.bool, device=device
                 )
-                # Snapshot-pool slot id the GDN layer should write into AT
+                # Snapshot arena slot the GDN layer should write into AT
                 # END OF THIS FORWARD for each seq, or -1 to skip. Populated
                 # by ``_cal_ssm_metadata`` from ``PrefixSegment.
                 # page2ssm_snapshot`` whenever the seq's prefill ends
@@ -247,7 +248,7 @@ class InputData:
           0``. This covers both chunked-prefill continuation and prefix-cache
           hits where ``PrefixMemoryManager`` already copied the snapshot back
           into the working slot.
-        * ``ssm_snapshot_write_slot_per_seq[i]`` = snapshot-pool slot id to
+        * ``ssm_snapshot_write_slot_per_seq[i]`` = snapshot arena slot id to
           which the GDN layer should copy this seq's working state at the
           end of this forward, or -1 if no snapshot is wanted. Populated
           only for prefill rows whose chunk ends exactly on a page boundary
@@ -258,6 +259,7 @@ class InputData:
         slots = np.empty(bs, dtype=np.int32)
         has_init = np.empty(bs, dtype=np.bool_)
         snap_targets = np.full(bs, -1, dtype=np.int32)
+        snapshot_candidates = []
 
         # Pull the snapshot pointer table once; ``PrefixSegment`` is the
         # only Segment subclass that owns ``page2ssm_snapshot``. The
@@ -273,9 +275,9 @@ class InputData:
             has_init[i] = seq.computed_token_num > 0
             # Snapshot timing: prefill chunk landing on a page boundary. The
             # state block is reserved HERE, lazily, and only for boundaries on
-            # the coarse ``ssm_snapshot_stride`` grid -- reserving one per
-            # cacheable page drained the shared block pool and starved sequence
-            # admission (see ``PrefixSegment.reserve_ssm_snapshot``). Decode rows
+            # the coarse ``ssm_snapshot_stride`` grid. Entries are borrowed
+            # dynamically from the shared arena and can later be reclaimed
+            # under KV/working-state pressure. Decode rows
             # skip this branch since ``computed_prompt`` flips True before any
             # decode token is emitted (see GenerationSequence), and ``reserve`` is None for
             # non-prefix-cache runs.
@@ -288,18 +290,23 @@ class InputData:
             if page_idx < 0 or page_idx >= len(seq.page_table):
                 continue
             page_num = seq.page_table[page_idx]
-            snap_slot = reserve(page_num, end_tokens)
-            if snap_slot is not None:
-                snap_targets[i] = snap_slot
-                # This forward WILL write the recurrent state for ``page_num``
-                # into ``snap_slot`` (see ``Qwen3_5GatedDeltaNet.
-                # _maybe_snapshot_state``). Mark the boundary as carrying a
-                # real snapshot so later prefix-cache hits may restore it.
-                # CPU bookkeeping is safe even under overlap scheduling: every
-                # SSM read/write is serialized on the GPU stream, so the
-                # restore copy for any future request is necessarily enqueued
-                # after this write completes.
-                segment.page2ssm_snapshot_valid[page_num] = True
+            if get_pp_size() == 1:
+                # Overlap scheduling prebuilds CPU metadata for a future batch.
+                # That batch may subsequently be compacted or discarded after
+                # the preceding async completion retires some rows. Reserving a
+                # snapshot here would therefore publish storage for a forward
+                # that might never launch. Keep only the allocation-free intent;
+                # ``copy_to_input_buffer`` materializes it immediately before
+                # H2D, after the prefetched batch is known to be executable.
+                snapshot_candidates.append((i, page_num, end_tokens))
+            else:
+                # PP followers need the driver's slot assignment in the
+                # scheduling payload, so retain the synchronous preparation
+                # protocol until PP supports overlap scheduling.
+                snap_slot = reserve(page_num, end_tokens)
+                if snap_slot is not None:
+                    snap_targets[i] = snap_slot
+                    segment.page2ssm_snapshot_valid[page_num] = True
 
         self.ssm_state_slot_per_seq_cpu = torch.as_tensor(
             slots, device="cpu"
@@ -310,6 +317,8 @@ class InputData:
         self.ssm_snapshot_write_slot_per_seq_cpu = (
             torch.as_tensor(snap_targets, device="cpu").pin_memory()
         )
+        self._ssm_snapshot_candidates = tuple(snapshot_candidates)
+        self._ssm_snapshot_writes_pending = ()
 
         # Spec-decode 2D block table plus accepted count for hybrid MTP.
         # Built only when at least one seq carries a ``ssm_block_table`` (MTP on).
@@ -342,6 +351,7 @@ class InputData:
 
     def copy_to_input_buffer(self):
         assert self.use_buffer
+        self._materialize_ssm_snapshot_targets()
         self.tokens[: self.tokens_cpu.shape[0]].copy_(
             self.tokens_cpu, non_blocking=True
         )
@@ -406,6 +416,51 @@ class InputData:
         self.cal_input(seqs)
         self.copy_to_input_buffer()
 
+    def _materialize_ssm_snapshot_targets(self) -> None:
+        """Reserve snapshot slots only for a batch that will really launch.
+
+        CPU metadata may live speculatively in the overlap worker. Allocation
+        and cache-validity are stateful, so they cannot happen during that
+        speculative phase. This method runs at the H2D boundary: no scheduler
+        allocation can interleave before the model forward is enqueued.
+        """
+        candidates = getattr(self, "_ssm_snapshot_candidates", ())
+        if not self.use_ssm_cache or not candidates:
+            return
+        segment = getattr(self.memory_manager, "segment", None)
+        reserve = getattr(segment, "reserve_ssm_snapshot", None)
+        if reserve is None:
+            self._ssm_snapshot_candidates = ()
+            return
+
+        targets = self.ssm_snapshot_write_slot_per_seq_cpu
+        pending = []
+        for row, page_num, end_tokens in candidates:
+            slot = reserve(page_num, end_tokens)
+            if slot is None:
+                continue
+            targets[row] = slot
+            pending.append((page_num, slot))
+        self._ssm_snapshot_candidates = ()
+        self._ssm_snapshot_writes_pending = tuple(pending)
+
+    def mark_ssm_snapshot_writes_enqueued(self) -> None:
+        """Publish snapshot validity after the GDN copy has been enqueued."""
+        pending = getattr(self, "_ssm_snapshot_writes_pending", ())
+        if not pending:
+            return
+        segment = getattr(self.memory_manager, "segment", None)
+        if segment is None:
+            self._ssm_snapshot_writes_pending = ()
+            return
+        for page_num, slot in pending:
+            # A mapping mismatch means arena pressure reclaimed the intent
+            # before launch. Never publish a different tenant as this page's
+            # recurrent state.
+            if segment.page2ssm_snapshot[page_num] == slot:
+                segment.page2ssm_snapshot_valid[page_num] = True
+        self._ssm_snapshot_writes_pending = ()
+
     def mark_gpu_buffer_shapes(
         self,
         *,
@@ -462,6 +517,8 @@ class InputData:
             cache[key] = shapes
         for name, tensor in shapes.items():
             setattr(self, name, tensor)
+        self._ssm_snapshot_candidates = ()
+        self._ssm_snapshot_writes_pending = ()
         self.seqs = seqs
         self.embedding_size = 0
         # mrope buffer is filled by the prep, but the captured graphs read the
@@ -541,6 +598,8 @@ class InputData:
         "ssm_state_slot_per_seq_cpu",
         "has_initial_state_per_seq_cpu",
         "ssm_snapshot_write_slot_per_seq_cpu",
+        "_ssm_snapshot_candidates",
+        "_ssm_snapshot_writes_pending",
     )
     _PREBUILT_MLA_ATTRS = (
         "num_actual_tokens",
@@ -712,7 +771,7 @@ class InputData:
         return self.ssm_num_accepted[: cpu.shape[0]]
 
     def get_ssm_snapshot_write_slot_per_seq(self):
-        """Per-seq snapshot-pool slot id to write at end of forward (-1=skip).
+        """Per-seq snapshot arena slot to write at end of forward (-1=skip).
 
         Returns ``None`` when SSM cache is disabled or when there are no
         rows to write (no enable_prefix_caching, no hybrid model). Layers

--- a/gllm/runtime/memory_manager.py
+++ b/gllm/runtime/memory_manager.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict, deque
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Union
 
@@ -5,10 +6,13 @@ import torch
 import torch.distributed as dist
 from logger import logger
 
-from collections import deque
-
 from gllm.distributed.parallel_state import get_pp_size
-from gllm.runtime.id_allocator import IDAllocator
+from gllm.runtime.cache_arena import (
+    CacheArena,
+    CacheLayout,
+    CacheTensorLayout,
+    RegisteredCache,
+)
 from gllm.runtime.sequence import GenerationSequence
 from gllm.utils import async_tensor_h2d, get_dtype_bytes
 
@@ -34,13 +38,14 @@ class SSMCacheConfig:
 
     Shapes (per layer, after TP sharding on the head dim):
 
-    * ``conv_state``  : ``(pool_size, conv_dim, conv_kernel - 1)``
-    * ``temporal_state``: ``(pool_size, num_v_heads, head_v_dim, head_k_dim)``
+    * ``conv_state``  : ``(num_slots, conv_dim, conv_kernel - 1)``
+    * ``temporal_state``: ``(num_slots, num_v_heads, head_v_dim, head_k_dim)``
 
-    Slot 0 in the working pool is reserved as the CUDA-graph dummy slot
+    Slot 0 in the working-state arena view is reserved as the CUDA-graph dummy
     (mirrors how :class:`MemoryManager` reserves a dummy KV page) so a padded
     decode row can write into it without polluting any real request's state.
     """
+
     num_layers: int
     conv_dim: int
     conv_kernel: int
@@ -68,81 +73,71 @@ class SSMCacheConfig:
     def temporal_state_shape_per_slot(self):
         return (self.num_v_heads, self.head_v_dim, self.head_k_dim)
 
-    def per_slot_bytes(self) -> int:
-        """Memory footprint of a *single* pool slot, summed across all linear
-        layers, post TP sharding. Used for SSM cache sizing logs.
-        """
-        conv_bytes = get_dtype_bytes(self.conv_state_dtype) * \
-            self.conv_dim * (self.conv_kernel - 1)
-        temp_bytes = get_dtype_bytes(self.dtype) * \
-            self.num_v_heads * self.head_v_dim * self.head_k_dim
-        return self.num_layers * (conv_bytes + temp_bytes)
-
-
 class SSMSegment:
-    """Twin tensor banks for the GDN/Mamba recurrent state.
+    """GDN/Mamba tensor views and lifecycle over the shared cache arena.
 
-    Two independent pools share the same per-slot tensor layout:
+    Working state and prefix snapshots register separate allocation types so
+    the arena can treat snapshots as pressure-reclaimable, but both types use
+    the same aligned slot grid and the same conv/temporal tensor views. Their
+    slot ids are therefore directly usable by the existing GDN kernels. Slot 0
+    of the working type is reserved for CUDA-graph padding.
 
-    * **Working pool**: one slot per *live* request. Holds the conv + temporal
-      state that gets mutated in place by every forward.
-    * **Snapshot pool**: one slot per *cached prefix page*. Holds a frozen copy
-      of the working state at a page boundary so a future prefix-cache hit can
-      restore it into a fresh working slot via :meth:`copy_state`.
-
-    Each pool exposes its own :class:`IDAllocator`; slot ids are independent
-    across the two pools. Both pools always reserve slot 0 as a CUDA-graph
-    padding dummy.
+    The segment never allocates storage itself. Both working state and prefix
+    snapshots are registered cache layouts over the process-wide arena.
     """
 
     def __init__(
         self,
         cfg: SSMCacheConfig,
-        num_blocks: int,
+        *,
+        state_cache: RegisteredCache,
+        snapshot_cache: RegisteredCache,
     ):
         self.cfg = cfg
-        # Shared recurrent-state block pool. Each block holds ONE full per-layer
+        if state_cache.arena is not snapshot_cache.arena:
+            raise ValueError("SSM working state and snapshots must share one arena")
+        if state_cache.layout.tensors != snapshot_cache.layout.tensors:
+            raise ValueError("SSM working state and snapshot layouts must match")
+        self.cache_arena = state_cache.arena
+        self.arena_type = state_cache.name
+        self.snapshot_arena_type = snapshot_cache.name
+        # Each logical block holds ONE full per-layer
         # GDN recurrent state (conv window + temporal state). A running sequence
         # borrows one block for its rolling state; an MTP verify step transiently
         # borrows ``k`` extra blocks per seq for the per-token checkpoints; a
-        # prefix-cached prefix keeps its state in a ref-counted block borrowed
-        # from THIS SAME pool (there is no separate snapshot pool anymore -- the
-        # cached-state block lives here and is copied into a fresh working block
-        # on a cache hit, so GDN's in-place updates never touch the cached copy).
-        # The pool size is derived from the memory budget, NOT from
-        # ``maxd``; max concurrency is *bounded by* ``num_blocks``.
-        # +1 keeps block 0 reserved as the CUDA-graph dummy block.
-        self.num_blocks = num_blocks + 1
-        # Back-compat alias: some call sites / logs still read working_pool_size.
-        self.working_pool_size = self.num_blocks
-
+        # prefix-cached prefix keeps its state in a reclaimable arena slot. The
+        # cached state is copied into a fresh working slot on a hit, so GDN's
+        # in-place updates never touch the cached copy.
+        self.num_blocks = state_cache.num_slots
         conv_shape = cfg.conv_state_shape_per_slot()
         temp_shape = cfg.temporal_state_shape_per_slot()
-        device = torch.device("cuda", torch.cuda.current_device())
 
         # Layout: ``[num_layers, num_blocks, *per_block]`` as a single stacked
-        # tensor (not a Python list of per-layer tensors). ``conv_state[layer_id]``
-        # still returns that layer's ``[num_blocks, *per_block]`` slice -- a
-        # contiguous view -- so every per-layer call site (kernels, ``copy_state``,
-        # ``zero_``) is unchanged. The stacked layout lets ``commit_blocks`` copy
+        # tensor view. ``conv_state[layer_id]`` still returns that layer's
+        # ``[num_blocks, *per_block]`` slice, now with an arena entry stride.
+        # Kernels consume the explicit stride. The stacked view lets
+        # ``commit_blocks`` copy
         # the checkpoint across ALL layers in one ``index_copy_`` (2 kernel
         # launches total) instead of ``2 * num_layers`` per-layer launches.
-        # ``torch.zeros`` (not ``empty``) because the SSM kernels read from
-        # block 0 / freshly-allocated blocks before the first write and require a
-        # clean initial state (h_0 = 0).
-        self.conv_state = torch.zeros(
-            (cfg.num_layers, self.num_blocks, *conv_shape),
-            dtype=cfg.conv_state_dtype,
-            device=device,
-        )
-        self.temporal_state = torch.zeros(
-            (cfg.num_layers, self.num_blocks, *temp_shape),
-            dtype=cfg.dtype,
-            device=device,
-        )
+        # Registered tensors are slot-major; recurrent kernels use layer-major
+        # views. ``movedim`` changes only metadata and retains the stable arena
+        # entry stride required by CUDA Graph replay.
+        self.conv_state = state_cache.tensor("conv_state").movedim(1, 0)
+        self.temporal_state = state_cache.tensor("temporal_state").movedim(1, 0)
+        if self.conv_state.shape != (cfg.num_layers, self.num_blocks, *conv_shape):
+            raise ValueError(self.conv_state.shape)
+        if self.temporal_state.shape != (
+            cfg.num_layers,
+            self.num_blocks,
+            *temp_shape,
+        ):
+            raise ValueError(self.temporal_state.shape)
 
-        # Block 0 reserved as the CUDA-graph dummy.
-        self.working_alloc = IDAllocator(1, self.num_blocks - 1)
+        dummy = self.cache_arena.allocator.allocate(self.arena_type, slot=0)
+        if dummy != [0]:
+            raise RuntimeError(f"cache arena did not reserve SSM frame 0: {dummy}")
+        self.conv_state[:, 0].zero_()
+        self.temporal_state[:, 0].zero_()
 
         # Dummy slot that padded rows / unused pointers can refer to without
         # aliasing any real state.
@@ -160,15 +155,30 @@ class SSMSegment:
         # where it is already serialized with the forward.
         self.restore_stream: Optional["torch.cuda.Stream"] = None
 
-    # --- block pool -----------------------------------------------------
+    # --- block lifecycle ------------------------------------------------
     #
     # A "block" holds one full per-layer GDN recurrent state. Sequences borrow
     # one block for their rolling state; MTP verify borrows extra transient
-    # blocks for per-token checkpoints. ``allocate_working`` / ``free_working``
-    # are kept as aliases so pre-existing call sites keep working.
+    # blocks for per-token checkpoints.
 
-    def allocate_block(self) -> int:
-        return self.working_alloc.allocate()
+    def allocate_block(self) -> Optional[int]:
+        blocks = self.cache_arena.allocator.allocate(self.arena_type, 1)
+        if blocks is None:
+            return None
+        block = blocks[0]
+        self._zero_block(block)
+        return block
+
+    def _zero_block(self, block: int) -> None:
+        def _zero():
+            self.conv_state[:, block].zero_()
+            self.temporal_state[:, block].zero_()
+
+        if self.restore_stream is not None:
+            with torch.cuda.stream(self.restore_stream):
+                _zero()
+        else:
+            _zero()
 
     def free_block(self, block: int) -> None:
         if block is None or block == self.dummy_working_slot:
@@ -176,12 +186,11 @@ class SSMSegment:
         # Zero before returning so the next borrower starts from h_0 = 0
         # without needing an explicit "reset state" pass through every layer.
         # Stacked layout -> one ``zero_`` per state covers all layers.
-        self.conv_state[:, block].zero_()
-        self.temporal_state[:, block].zero_()
-        self.working_alloc.free(block)
+        self._zero_block(block)
+        self.cache_arena.allocator.free(self.arena_type, [block])
 
     def num_free_blocks(self) -> int:
-        return self.working_alloc.get_num_free_ids()
+        return self.cache_arena.allocator.num_available_slots(self.arena_type)
 
     def allocate_block_table(self, n: int) -> Optional[list]:
         """Borrow ``n`` blocks for a sequence's SSM state block table.
@@ -189,48 +198,45 @@ class SSMSegment:
         Speculative decode gives each sequence a fixed ``1+k`` block table:
         column 0 holds the rolling/committed state and columns 1..k hold verify
         checkpoints. Returns a list of ``n`` block ids, or ``None`` if
-        the pool cannot satisfy the whole request (caller must not partially
-        allocate -- the scheduler gates admission on ``num_free_blocks``).
+        the arena cannot satisfy the whole request. Allocation is atomic.
         """
-        if self.working_alloc.get_num_free_ids() < n:
+        blocks = self.cache_arena.allocator.allocate(self.arena_type, n)
+        if blocks is None:
             return None
-        return [self.working_alloc.allocate() for _ in range(n)]
+        for block in blocks:
+            self._zero_block(block)
+        return blocks
 
     def free_block_table(self, blocks) -> None:
-        """Return a sequence's whole SSM block table to the pool (zeroing each)."""
+        """Return a sequence's whole SSM block table to the arena."""
         if not blocks:
             return
-        for blk in blocks:
-            self.free_block(blk)
-
-    # Back-compat aliases (one working slot == one borrowed block).
-    def allocate_working(self) -> int:
-        return self.allocate_block()
-
-    def free_working(self, slot: int) -> None:
-        self.free_block(slot)
-
-    def num_free_working(self) -> int:
-        return self.num_free_blocks()
+        real_blocks = [
+            int(blk) for blk in blocks
+            if blk is not None and int(blk) != self.dummy_working_slot
+        ]
+        for blk in real_blocks:
+            self._zero_block(blk)
+        self.cache_arena.allocator.free(self.arena_type, real_blocks)
 
     # --- prefix-cache cached-state blocks ------------------------------
-    #
-    # A prefix-cached prefix keeps its recurrent state in a block borrowed from
-    # the SAME main pool (no separate snapshot pool). ``allocate_snapshot`` /
-    # ``free_snapshot`` are thin aliases over the block allocator so the
-    # PrefixSegment lifecycle code (which reserves a cached-state block per
-    # cacheable page and frees it on re-mint) reads naturally. Returns None when
-    # the pool is exhausted -> the caller degrades to "KV-cached but no SSM".
 
     def allocate_snapshot(self) -> Optional[int]:
-        if self.working_alloc.get_num_free_ids() == 0:
+        # Snapshot allocations are best effort. The allocator may use any free
+        # aligned extent, but does not evict one snapshot merely to create a
+        # different snapshot of the same type.
+        blocks = self.cache_arena.allocator.allocate(self.snapshot_arena_type, 1)
+        if blocks is None:
             return None
-        return self.working_alloc.allocate()
+        block = blocks[0]
+        self._zero_block(block)
+        return block
 
     def free_snapshot(self, slot: int) -> None:
         if slot is None or slot == self.dummy_working_slot:
             return
-        self.free_block(slot)
+        self._zero_block(slot)
+        self.cache_arena.allocator.free(self.snapshot_arena_type, [slot])
 
     def num_free_snapshot(self) -> int:
         return self.num_free_blocks()
@@ -244,9 +250,10 @@ class SSMSegment:
         dst_kind: str,
         dst_slot: int,
     ) -> None:
-        """Copy a full multi-layer recurrent state between two blocks of the
-        shared pool. ``src_kind``/``dst_kind`` ("working"/"snapshot") are only
-        semantic labels for the copy direction; both index the same pool.
+        """Copy a full multi-layer recurrent state between two arena entries.
+
+        ``src_kind``/``dst_kind`` ("working"/"snapshot") are semantic labels
+        for the copy direction; both index the same strided tensor view.
 
         * Prefill capture: ``copy_state("working", req_block, "snapshot",
           cached_block)`` after the GDN layer crosses a cacheable page boundary.
@@ -278,26 +285,24 @@ class SSMSegment:
             _do_copies()
 
     def _pool(self, kind: str):
-        # Both "working" and "snapshot" now live in the SAME block pool -- the
-        # kind is just a semantic label for the copy direction (capture vs
-        # restore). Cached-state ("snapshot") blocks and live rolling
-        # ("working") blocks are distinct block ids in ``conv_state`` /
-        # ``temporal_state``; the copy is always between different block ids.
+        # Working state and snapshots use the same logical grid over the same
+        # physical arena. The kind only documents capture vs restore; the two
+        # entries always have distinct live ownership.
         if kind in ("working", "snapshot"):
             return self.conv_state, self.temporal_state
-        raise ValueError(f"unknown ssm pool kind: {kind!r}")
+        raise ValueError(f"unknown SSM state kind: {kind!r}")
 
     # --- MTP verify checkpoint commit ----------------------------------
     #
     # An MTP verify forward runs the GDN recurrent kernel over [x1, d1..dk] and
-    # checkpoints the state after each token into a set of transient blocks
-    # borrowed from this same pool (one block per verify step, per sequence).
+    # checkpoints the state after each token into transient arena entries (one
+    # entry per verify step, per sequence).
     # The verify forward does NOT write the sequence's rolling block (it passes
     # ``disable_state_update``). After the accept step knows each seq committed
     # ``1+na`` tokens, we copy the step-``na`` checkpoint block's contents into
     # the sequence's rolling block -- the exact post-commit recurrent state,
     # with no rollback and no recompute forward. The transient blocks are then
-    # freed back to the shared pool. One rolling block remains the source of
+    # returned to the arena. One rolling block remains the source of
     # truth so ordinary one-token decode is unchanged; the selected checkpoint
     # is committed there before the transient blocks are released.
 
@@ -315,9 +320,7 @@ class SSMSegment:
         dev = self.conv_state.device
         dst = torch.as_tensor([c[0] for c in commit], dtype=torch.long, device=dev)
         src = torch.as_tensor([c[1] for c in commit], dtype=torch.long, device=dev)
-        self.conv_state.index_copy_(
-            1, dst, self.conv_state.index_select(1, src)
-        )
+        self.conv_state.index_copy_(1, dst, self.conv_state.index_select(1, src))
         self.temporal_state.index_copy_(
             1, dst, self.temporal_state.index_select(1, src)
         )
@@ -327,11 +330,11 @@ class Segment:
     def __init__(
         self,
         num_layers: int,
-        num_pages: int,
         page_size: int,
         kv_head_num: int,
         kv_head_dim: int,
         use_mla: bool,
+        cache: RegisteredCache,
         index_head_dim: int = 0,
         qk_rope_head_dim: int = 0,
         mla_cache_fp8: bool = False,
@@ -351,7 +354,7 @@ class Segment:
         the same ``slot_mapping`` as the MLA latent.
         """
         self.num_layers = num_layers
-        self.num_pages = num_pages
+        self.num_pages = cache.num_slots
         self.page_size = page_size
         self.kv_head_num = kv_head_num
         self.kv_head_dim = kv_head_dim
@@ -363,78 +366,45 @@ class Segment:
         # bf16 latent cache + dense decode, which is exact for prompts <=
         # index_topk. Every non-DSA model keeps its bf16 latent cache unchanged.
         self.mla_cache_fp8 = use_mla and index_head_dim > 0 and mla_cache_fp8
-        device = torch.device("cuda", torch.cuda.current_device())
-        # Packed FP8 layout size: kv_lora_rank(=kv_head_dim - qk_rope) FP8 bytes
-        # + (kv_lora_rank/128) fp32 scale bytes + qk_rope_head_dim bf16 bytes.
-        # For MLA, kv_head_dim = kv_lora_rank + qk_rope_head_dim.
-
         if not use_mla:
-            # We don't need zero initialization here
-            self.k_cache = [
-                torch.ones(
-                    (num_pages, page_size, kv_head_num, kv_head_dim), device=device
-                )
-                for _ in range(num_layers)
-            ]
-            self.v_cache = [
-                torch.ones(
-                    (num_pages, page_size, kv_head_num, kv_head_dim), device=device
-                )
-                for _ in range(num_layers)
-            ]
-        elif self.mla_cache_fp8:
-            # kv_head_dim is kv_lora_rank + qk_rope_head_dim (e.g. 512 + 64).
-            qk_rope = qk_rope_head_dim
-            kv_lora = kv_head_dim - qk_rope
-            assert kv_lora % _DSA_FP8_TILE == 0, (
-                f"kv_lora_rank {kv_lora} must be divisible by FP8 tile "
-                f"{_DSA_FP8_TILE} for the DSA FP8 MLA cache"
+            keys = cache.tensor("key")
+            values = cache.tensor("value")
+            expected = (
+                self.num_pages,
+                num_layers,
+                page_size,
+                kv_head_num,
+                kv_head_dim,
             )
-            num_tiles = kv_lora // _DSA_FP8_TILE
-            self.mla_fp8_dim = kv_lora + num_tiles * 4 + qk_rope * 2  # 656
-            self.kv_cache = [
-                torch.zeros(
-                    (num_pages, page_size, 1, self.mla_fp8_dim),
-                    dtype=torch.float8_e4m3fn,
-                    device=device,
-                )
-                for _ in range(num_layers)
-            ]
+            if keys.shape != expected or values.shape != expected:
+                raise ValueError((keys.shape, values.shape, expected))
+            self.k_cache = [keys[:, layer] for layer in range(num_layers)]
+            self.v_cache = [values[:, layer] for layer in range(num_layers)]
         else:
-            self.kv_cache = [
-                torch.ones((num_pages, page_size, kv_head_dim), device=device)
-                for _ in range(num_layers)
-            ]
+            latent = cache.tensor("mla")
+            if self.mla_cache_fp8:
+                self.mla_fp8_dim = latent.shape[-1]
+            self.kv_cache = [latent[:, layer] for layer in range(num_layers)]
         # DeepSeek Sparse Attention: parallel indexer key cache (bf16, one
         # single-head index_head_dim vector per token per layer). Only
         # allocated when index_head_dim > 0.
         if index_head_dim > 0:
-            self.index_k_cache = [
-                torch.zeros(
-                    (num_pages, page_size, index_head_dim), device=device
-                )
-                for _ in range(num_layers)
-            ]
+            index = cache.tensor("index_key")
+            self.index_k_cache = [index[:, layer] for layer in range(num_layers)]
             # DSA FP8 indexer scoring: a parallel paged FP8 index-K cache in the
             # 132-byte block-contiguous layout the deep_gemm paged-MQA-logits
             # kernel reads (per page: [page_size*index_head_dim fp8][page_size*
             # (index_head_dim/128)*4 scale]). ``index_head_dim`` (128) => 128 fp8
             # + 4 scale = 132 bytes/token.
-            assert index_head_dim % _DSA_FP8_TILE == 0
-            n_sf = index_head_dim // _DSA_FP8_TILE  # scales per token (=1)
-            self.index_fp8_bytes = index_head_dim + n_sf * 4  # 132
+            index_fp8 = cache.tensor("index_key_fp8")
+            self.index_fp8_bytes = index_fp8.shape[-1] // page_size
             self.index_k_fp8_cache = [
-                torch.zeros(
-                    (num_pages, page_size * self.index_fp8_bytes),
-                    dtype=torch.uint8,
-                    device=device,
-                )
-                for _ in range(num_layers)
+                index_fp8[:, layer] for layer in range(num_layers)
             ]
         else:
             self.index_k_cache = None
             self.index_k_fp8_cache = None
-        self.id_allocator = IDAllocator(0, num_pages - 1)
+        self.id_allocator = cache.slot_allocator()
 
     def allocate(self):
         pagenum = self.id_allocator.allocate()
@@ -442,6 +412,9 @@ class Segment:
 
     def free(self, page_num: int):
         self.id_allocator.free(page_num)
+
+    def free_many(self, page_nums) -> None:
+        self.id_allocator.free_many(int(page) for page in page_nums)
 
     def get_num_free_pages(self):
         return self.id_allocator.get_num_free_ids()
@@ -465,8 +438,6 @@ class MemoryManager:
         vocab_size: int,
         use_mla: bool = False,
         ssm_cache_config: Optional[SSMCacheConfig] = None,
-        max_working_ssm_slots: int = 0,
-        max_snapshot_ssm_slots: int = 0,
         max_running_seqs: int = 256,
         index_head_dim: int = 0,
         qk_rope_head_dim: int = 0,
@@ -483,22 +454,11 @@ class MemoryManager:
             kv_head_num: number of k/v heads (post-TP-shard).
             kv_head_dim: dimension of one k/v head.
             ssm_cache_config: layout for the recurrent (Mamba/GDN) state
-                cache. ``None`` disables the SSM segment entirely; the rest
-                of gllm behaves exactly as before (this is the path used by
-                every non-hybrid model).
-            max_working_ssm_slots: number of live request slots in the SSM
-                working pool. Should be ``>= max_running_seqs`` so the
-                scheduler always finds room.
-            max_snapshot_ssm_slots: number of cached-prefix slots in the SSM
-                snapshot pool. Set to 0 to disable SSM prefix caching while
-                keeping per-request SSM state. Otherwise this is the budget
-                for cross-request state reuse (mirrors sglang's
-                ``--max-mamba-cache-size``).
+                cache. ``None`` registers only the attention cache in the arena.
             ssm_snapshot_stride_tokens: token granularity of recurrent-state
                 prefix caching, rounded down to whole KV pages (see
                 ``PrefixSegment.ssm_snapshot_stride``). Smaller = finer restore
-                points but more snapshot blocks per prompt; the pool is shared
-                with the working state, so too small starves admission.
+                points but more reclaimable arena entries per prompt.
         """
         self.gpu_memory_util = gpu_memory_util
         self.num_layers = num_layers
@@ -519,8 +479,6 @@ class MemoryManager:
         # for prompts <= index_topk (the sparse top-k would select every key).
         self.mla_cache_fp8 = use_mla and index_head_dim > 0 and mla_cache_fp8
         self.ssm_cache_config = ssm_cache_config
-        self.max_working_ssm_slots = max_working_ssm_slots
-        self.max_snapshot_ssm_slots = max_snapshot_ssm_slots
         # Draft-chain length (mtp_k); a running seq borrows up to this many
         # transient checkpoint blocks during an MTP verify step (0 = MTP off).
         self.mtp_k = mtp_k
@@ -528,14 +486,9 @@ class MemoryManager:
         # whole pages and installed on the segment by
         # ``PrefixMemoryManager.init``; ignored without prefix caching.
         self.ssm_snapshot_stride_tokens = ssm_snapshot_stride_tokens
-        # Upper bound on the share of util-scaled free memory the SSM pools may
-        # occupy before the KV cache is sized. The snapshot pool (best-effort)
-        # is clamped to fit; the working pool (mandatory) is always honored.
-        # TODO: replace with a derived formula based on per_slot_bytes vs
-        #       kv_bytes_per_page so the split is model-aware.
-        self.ssm_pool_budget_frac: float = 0.5
         # Populated by :meth:`init`; ``None`` when the model is not hybrid.
         self.ssm_segment: Optional[SSMSegment] = None
+        self.cache_arena: Optional[CacheArena] = None
         self.segment: Union[Segment, PrefixSegment] = None
 
         # --- Persistent repetition-penalty mask pool --------------------
@@ -558,179 +511,192 @@ class MemoryManager:
         return self.ssm_cache_config is not None
 
     def consume_pending_ssm_restores(self) -> Dict[int, int]:
-        """No SSM prefix caching without a snapshot pool (base manager)."""
+        """No SSM prefix caching without prefix metadata (base manager)."""
         return {}
 
     def init(self, segment_cls=Segment, reserve_dummy_page: bool = False):
-        # Allocate SSM pools before sizing the KV cache so ``mem_get_info``
-        # reflects the true post-SSM free memory. Do not subtract an estimated
-        # byte count again afterward -- the tensors are already on CUDA.
-        self._init_ssm_segment_if_needed()
+        """Allocate one arena and register every persistent model cache."""
+        kv_layout = self._kv_cache_layout()
+        free_mem, _ = torch.cuda.mem_get_info()
+        kv_page_bytes = kv_layout.entry_bytes
+        arena_budget = int(free_mem * self.gpu_memory_util)
+        num_physical_pages = arena_budget // kv_page_bytes
+        if dist.is_initialized():
+            gathered = [None for _ in range(dist.get_world_size())]
+            dist.all_gather_object(gathered, num_physical_pages)
+            num_physical_pages = min(gathered)
+        if num_physical_pages <= 0:
+            raise RuntimeError("not enough GPU memory for one cache arena page")
 
-        free_mem_size, _ = torch.cuda.mem_get_info()
-        num_max_pages = free_mem_size // self.get_sizeof_KV_per_page()
-        num_pages = int(num_max_pages * self.gpu_memory_util)
-
-        if not dist.is_initialized():
-            self.num_pages = num_pages
-        else:
-            num_pages_all = [None for _ in range(dist.get_world_size())]
-            dist.all_gather_object(num_pages_all, num_pages)
-            self.num_pages = min(num_pages_all)
-
-        # KV cache element precision: native FP8 for DeepSeek Sparse Attention
-        # (packed 656-byte MLA latent), otherwise the model dtype (e.g. bf16).
-        if self.mla_cache_fp8:
-            kv_dtype_str = "fp8_e4m3 (nope) + bf16 (rope)"
-        else:
-            kv_dtype_str = str(self.dtype).replace("torch.", "")
-        logger.info(
-            f"KV cache: {self.num_pages} pages ({self.page_size} tokens/page), "
-            f"dtype {kv_dtype_str}, "
-            f"{round(self.get_sizeof_KV_per_page()/(2**10*self.page_size),2)} KB (per token), "
-            f"{round(self.num_pages*self.get_sizeof_KV_per_page()/(2**30),2)} GB (total)"
+        device = torch.device("cuda", torch.cuda.current_device())
+        backing = torch.empty(
+            num_physical_pages * kv_page_bytes,
+            dtype=torch.uint8,
+            device=device,
         )
-
+        arena = CacheArena(backing, physical_page_bytes=kv_page_bytes)
+        kv_cache = arena.register_cache(kv_layout)
+        self.cache_arena = arena
+        self.num_pages = kv_cache.num_slots
         self.segment = segment_cls(
             self.num_layers,
-            self.num_pages,
             self.page_size,
             self.kv_head_num,
             self.kv_head_dim,
             self.use_mla,
+            kv_cache,
             index_head_dim=self.index_head_dim,
             qk_rope_head_dim=self.qk_rope_head_dim,
             mla_cache_fp8=self.mla_cache_fp8,
         )
 
-        # Reserve a dedicated dummy page for CUDA graph padding only when
-        # CUDA graphs are enabled.  This page is never returned to normal use,
-        # so real sequences will never overwrite it, and padding dummy tokens
-        # can safely write here.
-        self.dummy_page: int = self.segment.allocate() if reserve_dummy_page else None
+        if self.ssm_cache_config is not None:
+            cfg = self.ssm_cache_config
+            state_cache = arena.register_cache(self._ssm_cache_layout("ssm_state"))
+            snapshot_cache = arena.register_cache(
+                self._ssm_cache_layout("ssm_snapshot")
+            )
+            per_seq_blocks = 1 + self.mtp_k
+            # Slot 0 is the graph-padding state and is never allocatable. This
+            # checks viability only; it does not reserve a separate SSM pool.
+            usable_ssm_slots = max(0, state_cache.num_slots - 1)
+            if usable_ssm_slots < per_seq_blocks:
+                need = (per_seq_blocks + 1) * state_cache.entry_bytes
+                raise RuntimeError(
+                    f"cache arena needs >= {need / (1 << 30):.1f} GB to run "
+                    f"one request with MTP k={self.mtp_k}, but its total budget "
+                    f"is {backing.numel() / (1 << 30):.1f} GB. Raise "
+                    "--gpu-memory-util or --tp."
+                )
+            self.ssm_segment = SSMSegment(
+                cfg,
+                state_cache=state_cache,
+                snapshot_cache=snapshot_cache,
+            )
+        else:
+            usable_ssm_slots = None
+
+        self.dummy_page = self.segment.allocate() if reserve_dummy_page else None
+
+        cache_names = ", ".join(arena.allocator.cache_type_names)
+        logger.info(
+            "Cache arena: %.2f GB, physical page %.2f KB; registered caches: "
+            "%s; KV=%d pages (%d tokens/page, %.2f KB/token)",
+            backing.numel() / (1 << 30),
+            kv_page_bytes / 1024,
+            cache_names,
+            self.num_pages,
+            self.page_size,
+            kv_page_bytes / (1024 * self.page_size),
+        )
+        if usable_ssm_slots is not None:
+            logger.info(
+                "Shared SSM capacity: %d slots, MTP state demand=%d slots/request",
+                usable_ssm_slots,
+                1 + self.mtp_k,
+            )
 
         self.kv_cache_dtype = "auto"
         self.k_scale = torch.tensor(1.0, dtype=torch.float32, device="cuda")
         self.v_scale = self.k_scale
 
-    def _init_ssm_segment_if_needed(self) -> None:
-        """Allocate the SSM block pool + snapshot pool when the model needs them.
-
-        For hybrid GDN/Mamba models each pool block holds the full per-layer
-        recurrent state. We size one shared block pool from the memory budget,
-        decoupled from ``maxd``. Every consumer borrows from it:
-
-        * a running seq borrows 1 rolling block; an MTP verify step borrows a
-          few transient checkpoint blocks; a prefix-cached prefix keeps its
-          state in a ref-counted block borrowed from this same pool.
-        * ``num_ssm_blocks = min(budget/per_block, working_cap + cache_cap)``
-          where ``working_cap = maxd * (1 + mtp_k)`` (max blocks live seqs can
-          borrow at once) and ``cache_cap`` (== requested prefix-cache blocks)
-          is best-effort headroom for cached-prefix reuse. Floored at ``maxd``
-          (>=1 rolling block per running seq) or we raise a clear error.
-        """
-        if self.ssm_cache_config is None:
-            return
-        cfg = self.ssm_cache_config
-        per_block = cfg.per_slot_bytes()
-
-        free_mem, _ = torch.cuda.mem_get_info()
-        budget = int(free_mem * self.gpu_memory_util * self.ssm_pool_budget_frac)
-
-        maxd = self.max_working_ssm_slots
-        # Blocks a single running seq may hold at once: 1 rolling + mtp_k
-        # transient checkpoint blocks during an MTP verify (0 extra when MTP off).
-        per_seq_blocks = 1 + self.mtp_k
-        working_cap = maxd * per_seq_blocks
-        # Best-effort headroom for prefix-cached-prefix state blocks (borrowed
-        # from the same pool, ref-counted alongside their KV page).
-        cache_cap = max(self.max_snapshot_ssm_slots, 0)
-        block_cap = working_cap + cache_cap
-        # Budget-derived block count (like KV pages = free_mem*util / kv_page).
-        affordable_blocks = int(budget // per_block)
-        num_ssm_blocks = min(block_cap, affordable_blocks)
-        # Floor: at least one rolling block per concurrently-running seq, else
-        # the scheduler could admit a seq with no state block. If even that
-        # doesn't fit, fail early with an actionable message.
-        if num_ssm_blocks < maxd:
-            need = maxd * per_block
-            raise RuntimeError(
-                f"SSM block pool needs >= {need / (1 << 30):.1f} GB for {maxd} "
-                f"concurrent sequences ({maxd} blocks x "
-                f"{per_block / (1 << 20):.1f} MB) but only "
-                f"{budget / (1 << 30):.1f} GB SSM budget is available. Lower "
-                f"--maxd (currently {maxd}) or raise --tp to shrink per-rank state."
-            )
-
-        # Keep every TP rank's pool layout identical (state is sharded, not
-        # replicated, but the block *count* must match across ranks); free
-        # memory can differ slightly per rank, so agree on the minimum.
-        if dist.is_initialized():
-            gathered = [None for _ in range(dist.get_world_size())]
-            dist.all_gather_object(gathered, num_ssm_blocks)
-            num_ssm_blocks = min(gathered)
-
-        # Prefix-cache headroom actually available after the mandatory working
-        # capacity (informational; the pool is shared so cache borrows compete
-        # with live seqs at runtime and degrade gracefully when tight).
-        cache_headroom = max(0, num_ssm_blocks - working_cap)
-        if cache_headroom < cache_cap:
-            logger.warning(
-                "SSM prefix-cache headroom %d -> %d blocks to fit the memory "
-                "budget (%.1f GB free, %.0f%% util, %.0f%% SSM share); prefix-cache "
-                "state reuse is %s. Lower --maxd or raise --tp for the full pool.",
-                cache_cap,
-                cache_headroom,
-                free_mem / (1 << 30),
-                self.gpu_memory_util * 100,
-                self.ssm_pool_budget_frac * 100,
-                "reduced" if cache_headroom > 0 else "disabled",
-            )
-
-        self.ssm_segment = SSMSegment(
-            cfg,
-            num_blocks=num_ssm_blocks,
-        )
-        total = per_block * self.ssm_segment.num_blocks
-        logger.info(
-            "SSM cache: %d state blocks (max decode concurrency ~%d, prefix-cache "
-            "headroom ~%d blocks), %.2f KB/block, %.2f GB total (linear-attn "
-            "layers: %d, temporal dtype: %s, conv dtype: %s)",
-            self.ssm_segment.num_blocks,
-            num_ssm_blocks // per_seq_blocks if per_seq_blocks else num_ssm_blocks,
-            cache_headroom,
-            per_block / 1024,
-            total / (1 << 30),
-            cfg.num_layers,
-            cfg.dtype,
-            cfg.conv_state_dtype,
-        )
-
-    def get_sizeof_KV_per_page(self):  # Bytes
+    def _kv_cache_layout(self) -> CacheLayout:
+        """Describe all tensor banks that share one attention-cache page id."""
+        tensors = []
         if not self.use_mla:
-            # 2: K cache and V cache
-            return (
-                2
-                * self.num_layers
-                * self.page_size
-                * self.kv_head_num
-                * self.kv_head_dim
-                * get_dtype_bytes(self.dtype)
+            shape = (
+                self.num_layers,
+                self.page_size,
+                self.kv_head_num,
+                self.kv_head_dim,
+            )
+            tensors.extend(
+                (
+                    CacheTensorLayout("key", self.dtype, shape),
+                    CacheTensorLayout("value", self.dtype, shape),
+                )
             )
         else:
-            # Per-token MLA latent bytes. Native FP8 (DSA) uses the packed
-            # 656-byte layout (1 byte/elem, computed in Segment as mla_fp8_dim);
-            # otherwise bf16 kv_head_dim. The index key cache adds its own
-            # per-token bytes (bf16) on top.
             if self.mla_cache_fp8:
                 qk_rope = self.qk_rope_head_dim
                 kv_lora = self.kv_head_dim - qk_rope
-                num_tiles = kv_lora // _DSA_FP8_TILE
-                mla_bytes = kv_lora + num_tiles * 4 + qk_rope * 2  # 656, 1 B/elem
+                if kv_lora % _DSA_FP8_TILE:
+                    raise ValueError(
+                        f"kv_lora_rank {kv_lora} must be divisible by "
+                        f"{_DSA_FP8_TILE} for the DSA FP8 MLA cache"
+                    )
+                mla_dim = (
+                    kv_lora
+                    + (kv_lora // _DSA_FP8_TILE) * 4
+                    + qk_rope * get_dtype_bytes(self.dtype)
+                )
+                tensors.append(
+                    CacheTensorLayout(
+                        "mla",
+                        torch.float8_e4m3fn,
+                        (self.num_layers, self.page_size, 1, mla_dim),
+                    )
+                )
             else:
-                mla_bytes = self.kv_head_dim * get_dtype_bytes(self.dtype)
-            index_bytes = self.index_head_dim * get_dtype_bytes(self.dtype)
-            return self.num_layers * self.page_size * (mla_bytes + index_bytes)
+                tensors.append(
+                    CacheTensorLayout(
+                        "mla",
+                        self.dtype,
+                        (self.num_layers, self.page_size, self.kv_head_dim),
+                    )
+                )
+
+        if self.index_head_dim > 0:
+            if self.index_head_dim % _DSA_FP8_TILE:
+                raise ValueError(
+                    f"index_head_dim {self.index_head_dim} must be divisible by "
+                    f"{_DSA_FP8_TILE}"
+                )
+            index_fp8_bytes = self.index_head_dim + (
+                self.index_head_dim // _DSA_FP8_TILE
+            ) * 4
+            tensors.extend(
+                (
+                    CacheTensorLayout(
+                        "index_key",
+                        self.dtype,
+                        (self.num_layers, self.page_size, self.index_head_dim),
+                    ),
+                    CacheTensorLayout(
+                        "index_key_fp8",
+                        torch.uint8,
+                        (
+                            self.num_layers,
+                            self.page_size * index_fp8_bytes,
+                        ),
+                    ),
+                )
+            )
+        return CacheLayout("kv_cache", tuple(tensors))
+
+    def _ssm_cache_layout(self, name: str) -> CacheLayout:
+        cfg = self.ssm_cache_config
+        if cfg is None:
+            raise RuntimeError("cannot register SSM cache without its config")
+        return CacheLayout(
+            name,
+            (
+                CacheTensorLayout(
+                    "conv_state",
+                    cfg.conv_state_dtype,
+                    (cfg.num_layers, *cfg.conv_state_shape_per_slot()),
+                ),
+                CacheTensorLayout(
+                    "temporal_state",
+                    cfg.dtype,
+                    (cfg.num_layers, *cfg.temporal_state_shape_per_slot()),
+                ),
+            ),
+            prefer_high=True,
+        )
+
+    def get_sizeof_KV_per_page(self):  # Bytes
+        return self._kv_cache_layout().entry_bytes
 
     def store_index_k(
         self,
@@ -823,9 +789,8 @@ class MemoryManager:
         if len(seqs) != len(seq_lens):
             raise ValueError((len(seqs), len(seq_lens)))
         for seq, seq_len in zip(seqs, seq_lens):
-            num_page = (
-                (int(seq_len) + self.page_size - 1) // self.page_size
-                - len(seq.page_table)
+            num_page = (int(seq_len) + self.page_size - 1) // self.page_size - len(
+                seq.page_table
             )
             for _ in range(num_page):
                 seq.page_table.append(self.segment.allocate())
@@ -835,8 +800,7 @@ class MemoryManager:
         return
 
     def free(self, seq: GenerationSequence):
-        for page_num in seq.page_table:
-            self.segment.free(page_num)
+        self.segment.free_many(seq.page_table)
         self.free_ssm_slot(seq)
         self.free_rep_slot(seq)
 
@@ -860,9 +824,7 @@ class MemoryManager:
         safety valve rather than a steady-state path.
         """
         old_rows = self._rep_pool.shape[0]
-        new_rows = torch.ones(
-            (extra, self.vocab_size), dtype=self.dtype, device="cuda"
-        )
+        new_rows = torch.ones((extra, self.vocab_size), dtype=self.dtype, device="cuda")
         self._rep_pool = torch.cat([self._rep_pool, new_rows], dim=0)
         self._rep_free_slots.extend(range(old_rows, old_rows + extra))
 
@@ -936,12 +898,14 @@ class MemoryManager:
         # 2) Gather the per-batch rows in a single op. Seqs with penalty 1.0
         #    (or no slot) map to the row-0 all-ones sentinel.
         batch_slots = [
-            seq.rep_slot
-            if (
-                getattr(seq, "repetition_penalty", 1.0) != 1.0
-                and seq.rep_slot is not None
+            (
+                seq.rep_slot
+                if (
+                    getattr(seq, "repetition_penalty", 1.0) != 1.0
+                    and seq.rep_slot is not None
+                )
+                else 0
             )
-            else 0
             for seq in seqs
         ]
         batch_slots_t = async_tensor_h2d(batch_slots, torch.long, "cuda", True)
@@ -954,26 +918,31 @@ class MemoryManager:
     # schedule of a sequence (mirroring how KV pages are pre-allocated) and
     # ``free_ssm_slot`` when the sequence finishes or is aborted/preempted.
 
-    def allocate_ssm_slot(self, seq: GenerationSequence) -> None:
+    def allocate_ssm_slot(self, seq: GenerationSequence) -> bool:
         if self.ssm_segment is None:
-            return
+            return True
         if self.mtp_k > 0:
             # MTP on: give the sequence a fixed 1+k block table (column 0 is
             # rolling state; the remaining columns are verify checkpoints).
             if seq.ssm_block_table is not None:
-                return
+                return True
             bt = self.ssm_segment.allocate_block_table(1 + self.mtp_k)
             if bt is None:
-                return  # pool exhausted; scheduler gates admission on this
+                return False  # arena exhausted; scheduler gates admission
             seq.ssm_block_table = bt
-            # Mirror column 0 into the scalar slot so any legacy single-slot
-            # reader (e.g. prefix-cache snapshot restore) still works.
+            # Column 0 is also the sequence's committed-state slot, shared by
+            # ordinary decode and prefix-cache snapshot restore.
             seq.ssm_state_slot = bt[0]
             seq.ssm_num_accepted = 1
+            return True
         else:
             if seq.ssm_state_slot is not None:
-                return
-            seq.ssm_state_slot = self.ssm_segment.allocate_working()
+                return True
+            slot = self.ssm_segment.allocate_block()
+            if slot is None:
+                return False
+            seq.ssm_state_slot = slot
+            return True
 
     def free_ssm_slot(self, seq: GenerationSequence) -> None:
         if self.ssm_segment is None:
@@ -986,7 +955,7 @@ class MemoryManager:
             return
         if seq.ssm_state_slot is None:
             return
-        self.ssm_segment.free_working(seq.ssm_state_slot)
+        self.ssm_segment.free_block(seq.ssm_state_slot)
         seq.ssm_state_slot = None
 
     def get_num_free_pages(self):
@@ -1056,7 +1025,7 @@ def _ensure_page_hash(seq: GenerationSequence, page_size: int, page_idx: int) ->
     while len(cache) <= page_idx:
         i = len(cache)
         prev = cache[i - 1] if i > 0 else _PREFIX_HASH_SEED
-        page_tokens = tuple(src[i * page_size:(i + 1) * page_size])
+        page_tokens = tuple(src[i * page_size : (i + 1) * page_size])
         cache.append(hash((prev, page_tokens)))
     return cache[page_idx]
 
@@ -1099,34 +1068,28 @@ class PrefixMemoryManager(MemoryManager):
     def init(self, reserve_dummy_page: bool = False):
         super().init(segment_cls=PrefixSegment, reserve_dummy_page=reserve_dummy_page)
         self.segment.ssm_segment = self.ssm_segment
-        # Watermark for lazy cached-state reservation: the cache may only use
-        # blocks *beyond* the full concurrency budget (``maxd * (1 + mtp_k)``),
-        # which is exactly how the pool was sized (``block_cap = working_cap +
-        # cache_cap`` in ``_init_ssm_segment_if_needed``). Without this the
-        # cache eats the working budget, the scheduler's admission gate (needs
-        # ``1 + mtp_k`` free blocks per new sequence) starves, and the running
-        # batch collapses to one sequence with a full wait queue.
-        self.segment.ssm_reserve_floor = (
-            self.max_working_ssm_slots * (1 + self.mtp_k)
-            if self.ssm_segment is not None
-            else 0
+        self.cache_arena.allocator.set_evictor(
+            "kv_cache", self.segment.evict_arena_slot
         )
+        if self.ssm_segment is not None:
+            self.cache_arena.allocator.set_reclaimer(
+                "ssm_snapshot", self.segment.reclaim_one_ssm_snapshot
+            )
         # Recurrent-state caching granularity for this run. Rounded DOWN to
         # whole pages (only page boundaries can carry a snapshot) with a floor
-        # of one page; a request below ``page_size`` therefore degrades to
-        # per-page snapshots, which is the configuration that drained the block
-        # pool (see ``PrefixSegment.ssm_snapshot_stride``), so say so out loud.
+        # of one page. A request below ``page_size`` therefore degrades to
+        # per-page snapshots, which increases state-copy work and arena churn.
         stride_tokens = int(self.ssm_snapshot_stride_tokens)
         if stride_tokens < self.page_size:
             logger.warning(
                 "ssm_snapshot_stride_tokens=%d is below page_size=%d; clamping to "
-                "one page. Per-page recurrent-state caching reserves a state block "
-                "per %d tokens of prompt and can starve sequence admission.",
-                stride_tokens, self.page_size, self.page_size,
+                "one page. Recurrent-state caching may materialize a reclaimable "
+                "snapshot every %d prompt tokens.",
+                stride_tokens,
+                self.page_size,
+                self.page_size,
             )
-        self.segment.ssm_snapshot_stride = max(
-            1, stride_tokens // self.page_size
-        )
+        self.segment.ssm_snapshot_stride = max(1, stride_tokens // self.page_size)
         if self.ssm_segment is not None:
             logger.info(
                 "SSM snapshot stride: %d tokens (%d pages)",
@@ -1139,9 +1102,9 @@ class PrefixMemoryManager(MemoryManager):
         self.num_hit_pages = 0
 
         # PP>1 only: SSM snapshot restores performed this scheduling iteration,
-        # keyed by seq_id -> snapshot-pool slot. Each PP follower owns a
+        # keyed by seq_id -> snapshot arena slot. Each PP follower owns a
         # *different* slice of the GDN layers on its own GPU, so the restore
-        # (snapshot->working ``copy_state``) the driver runs on rank-0's pools
+        # (snapshot->working ``copy_state``) the driver runs on rank-0's views
         # must be replayed on every stage. The driver records the restores here
         # and the payload builder ships them; ``consume`` clears the buffer so
         # each is shipped exactly once.
@@ -1209,12 +1172,16 @@ class PrefixMemoryManager(MemoryManager):
         them.
         """
         while seq.computed_token_num > 0:
-            boundary_page = seq.page_table[
-                seq.computed_token_num // self.page_size - 1
-            ]
+            boundary_page = seq.page_table[seq.computed_token_num // self.page_size - 1]
             snap_slot = self._valid_snapshot_slot(boundary_page)
             if snap_slot is not None:
-                self.allocate_ssm_slot(seq)
+                if not self.allocate_ssm_slot(seq):
+                    # The prefix remains cached, but without a private mutable
+                    # state slot this request must wait for arena capacity.
+                    hit_pages = seq.computed_token_num // self.page_size
+                    seq.computed_token_num = 0
+                    self.num_hit_pages = max(0, self.num_hit_pages - hit_pages)
+                    return
                 self.ssm_segment.copy_state(
                     "snapshot", snap_slot, "working", seq.ssm_state_slot
                 )
@@ -1269,9 +1236,7 @@ class PrefixMemoryManager(MemoryManager):
         ``register_decode_boundary`` (from the scheduler's finalize hook).
         """
         for seq in seqs:
-            seq_cacheable = cacheable and not getattr(
-                seq, "_mtp_async_pending", False
-            )
+            seq_cacheable = cacheable and not getattr(seq, "_mtp_async_pending", False)
             len_page_table = len(seq.page_table)
             num_page = (
                 seq.seq_len + self.page_size - 1
@@ -1302,6 +1267,8 @@ class PrefixMemoryManager(MemoryManager):
         zeros and must never be restored onto a non-empty prefix."""
         if not self.segment.page2ssm_snapshot_valid[page_num]:
             return None
+        if page_num in self.segment._ssm_snapshot_lru:
+            self.segment._ssm_snapshot_lru.move_to_end(page_num)
         return self.segment.page2ssm_snapshot[page_num]
 
     def get_cache_hit_rate(self):
@@ -1326,12 +1293,11 @@ class PrefixSegment(Segment):
     implementation could silently share KV across two distinct prefixes
     whose ``hash()`` happened to match.
 
-    SSM extension: for every cached page we keep an optional snapshot slot
-    in the partner :class:`SSMSegment`. When a sequence allocates a page
-    in :meth:`PrefixMemoryManager.pre_allocate_page`, a snapshot slot is
-    reserved alongside; the GDN layer fills it after the page boundary is
-    crossed during prefill. On a cache hit the snapshot is copied back into
-    the requesting sequence's working slot.
+    SSM extension: every cached page may reference a snapshot entry in the
+    partner :class:`SSMSegment`. The entry is borrowed lazily only when a
+    prefill forward reaches an eligible page boundary, and remains reclaimable
+    under arena pressure. On a cache hit the snapshot is copied back into the
+    requesting sequence's working entry.
     """
 
     # Set by :class:`PrefixMemoryManager.init`.
@@ -1342,19 +1308,11 @@ class PrefixSegment(Segment):
     # :meth:`PrefixMemoryManager.init` from ``--ssm-snapshot-stride-tokens``;
     # the value here is only a floor for a segment built outside that path.
     #
-    # This used to be every cacheable page: ``allocate`` reserved one state
-    # block per 16-token page, so a single 2.5k-token prompt reserved ~156
-    # blocks out of a ~1800-block pool. Ten such requests drained it, and
-    # since new admissions need ``1 + mtp_k`` blocks from the same pool the
-    # scheduler then stalled with #run=1 and 120+ queued (observed on
-    # MMLU-Pro 5-shot). Worse, those reservations were nearly all dead
-    # weight: a state is only ever *written* at a chunk end, so the interior
-    # boundaries kept a reserved-but-zeroed block forever and every hit was
-    # rejected on the SSM half -> 0% cache hit rate. Coarse + lazy (see
-    # ``reserve_ssm_snapshot``) fixes both: ~10 blocks per prompt, and only
-    # for boundaries a chunk actually lands on. Restoring from a coarse
-    # boundary means recomputing at most ``stride`` pages of tail, trading a
-    # bounded amount of recompute for a much smaller snapshot pool.
+    # Only boundaries that a prefill chunk actually reaches are materialized;
+    # reserving entries at allocation time would leave most of them unwritten.
+    # A coarse stride reduces state-copy traffic and metadata. It is not a
+    # capacity partition: every materialized snapshot freely borrows an arena
+    # extent and remains pressure-reclaimable.
     ssm_snapshot_stride: int = 1
 
     def __init__(self, *args, **kwargs):
@@ -1368,15 +1326,46 @@ class PrefixSegment(Segment):
         # SSM snapshot slot id per physical page; ``None`` if no snapshot
         # was captured (e.g. when the SSM cache is disabled or the boundary
         # never had a chance to snapshot during prefill).
-        self.page2ssm_snapshot: List[Optional[int]] = [None for _ in range(self.num_pages)]
+        self.page2ssm_snapshot: List[Optional[int]] = [
+            None for _ in range(self.num_pages)
+        ]
         # Whether the snapshot slot actually holds a *written* recurrent state.
         # A slot only ever gets written for the boundary a prefill chunk *ends*
         # on (see ``InputData._cal_ssm_metadata``); this flag separates
         # "reserved" from "filled" so the restore path never grafts a zeroed
         # state (== h_0) onto a non-empty prefix.
-        self.page2ssm_snapshot_valid: List[bool] = [False for _ in range(self.num_pages)]
+        self.page2ssm_snapshot_valid: List[bool] = [
+            False for _ in range(self.num_pages)
+        ]
+        self._ssm_snapshot_lru: "OrderedDict[int, None]" = OrderedDict()
 
     # --- public API ---------------------------------------------------------
+
+    def evict_arena_slot(self, page_num: int) -> None:
+        """Invalidate an unpinned KV entry before another arena type reuses it."""
+        if self.page_ref_num[page_num] != 0:
+            raise RuntimeError(
+                f"arena attempted to evict pinned KV page {page_num} "
+                f"(refs={self.page_ref_num[page_num]})"
+            )
+        page_hash = self.page2hash[page_num]
+        if page_hash and self.hash2page.get(page_hash) == page_num:
+            del self.hash2page[page_hash]
+        self._release_snapshot_for(page_num)
+        self.page2hash[page_num] = 0
+        self.page2canary[page_num] = None
+        self.page2ssm_snapshot[page_num] = None
+        self.page2ssm_snapshot_valid[page_num] = False
+
+    def reclaim_one_ssm_snapshot(self) -> bool:
+        """Release the least-recently-used snapshot under arena pressure."""
+        while self._ssm_snapshot_lru:
+            page_num, _ = self._ssm_snapshot_lru.popitem(last=False)
+            if self.page2ssm_snapshot[page_num] is None:
+                continue
+            self._release_snapshot_for(page_num)
+            return True
+        return False
 
     def update(self, seq: GenerationSequence, n_tokens: int, page_num: int) -> None:
         """Register a hash for ``page_num`` after its KV was filled in decode."""
@@ -1407,7 +1396,9 @@ class PrefixSegment(Segment):
         self.page_ref_num[page_num] += 1
         return page_num
 
-    def allocate(self, seq: Optional[GenerationSequence] = None, n_tokens: Optional[int] = None):
+    def allocate(
+        self, seq: Optional[GenerationSequence] = None, n_tokens: Optional[int] = None
+    ):
         """Allocate a page; optionally register a prefix hash for it.
 
         Signature is overloaded:
@@ -1460,24 +1451,36 @@ class PrefixSegment(Segment):
             # the ref-count hitting zero (its ``hash2page`` entry stays
             # registered until the page is re-minted for a *different*
             # prompt by :meth:`allocate`). The SSM snapshot must follow
-            # the same lifetime — otherwise a serial re-use of a cached
+            # the same lifetime — otherwise serial reuse of a cached
             # prompt would always lose the snapshot half of the hit and
-            # ``_rollback_to_last_ssm_hit`` would drop the KV half too.
+            # ``_restore_ssm_working_state`` would drop the KV half too.
             self.id_allocator.free(page_num)
 
+    def free_many(self, page_nums) -> None:
+        """Drop a request's KV references and batch-release newly unpinned pages."""
+        released = []
+        for value in page_nums:
+            page_num = int(value)
+            assert self.page_ref_num[page_num] > 0
+            self.page_ref_num[page_num] -= 1
+            if self.page_ref_num[page_num] == 0:
+                released.append(page_num)
+        if not released:
+            return
+        self.id_allocator.free_many(released)
+
     def reserve_ssm_snapshot(self, page_num: int, n_tokens: int) -> Optional[int]:
-        """Lazily reserve the cached-state block for ``page_num``, or ``None``.
+        """Lazily borrow a cached-state entry for ``page_num``, or ``None``.
 
         Called from the *write* path (``InputData._cal_ssm_metadata``) for the
-        boundary a prefill chunk just landed on, so a block is only ever taken
+        boundary a prefill chunk just landed on, so an entry is only ever taken
         for a boundary that will actually hold a state. Returns ``None`` when:
 
         * the boundary is not on the coarse ``ssm_snapshot_stride`` grid,
         * the page is not cacheable (nothing could ever hit it), or
-        * the pool is at its watermark -- cached states must never eat the
-          blocks that live sequences need for their rolling state, otherwise
-          the scheduler's admission gate (which needs ``1 + mtp_k`` free blocks
-          per new sequence) starves and the batch collapses to one sequence.
+        * no arena extent is currently available. Snapshots are reclaimable;
+          live KV/working-state pressure can evict them later without a fixed
+          watermark or reserved sub-pool.
         """
         if self.ssm_segment is None:
             return None
@@ -1488,13 +1491,12 @@ class PrefixSegment(Segment):
         slot = self.page2ssm_snapshot[page_num]
         if slot is not None:
             return slot
-        if self.ssm_segment.num_free_blocks() <= self.ssm_reserve_floor:
-            return None
         slot = self.ssm_segment.allocate_snapshot()
         if slot is None:
             return None
         self.page2ssm_snapshot[page_num] = slot
         self.page2ssm_snapshot_valid[page_num] = False
+        self._ssm_snapshot_lru[page_num] = None
         return slot
 
     def _release_snapshot_for(self, page_num: int) -> None:
@@ -1504,4 +1506,5 @@ class PrefixSegment(Segment):
         if snap_slot is not None:
             self.ssm_segment.free_snapshot(snap_slot)
             self.page2ssm_snapshot[page_num] = None
+            self._ssm_snapshot_lru.pop(page_num, None)
         self.page2ssm_snapshot_valid[page_num] = False

--- a/gllm/runtime/model_loader.py
+++ b/gllm/runtime/model_loader.py
@@ -687,6 +687,25 @@ class ModelLoader:
             if isinstance(self.weights, LazySafetensors):
                 self.weights.close()
 
+        # Backend-specific weight layouts are materialized only after every
+        # checkpoint tensor has reached its final parameter. Unsupported
+        # layers keep their native layout and continue through their existing
+        # backend.
+        moe_backends: dict[str, int] = {}
+        for module in model.modules():
+            quant_method = getattr(module, "quant_method", None)
+            process = getattr(quant_method, "process_weights_after_loading", None)
+            if process is not None:
+                process(module)
+            backend = getattr(quant_method, "backend", None)
+            if backend is not None:
+                moe_backends[backend] = moe_backends.get(backend, 0) + 1
+        if moe_backends:
+            summary = ", ".join(
+                f"{backend}={count}" for backend, count in sorted(moe_backends.items())
+            )
+            logger.info("MoE backend selection: %s", summary)
+
         # Best-effort validation that ``quantization_config["ignored_layers"]``
         # is honored. gllm does not consume the field directly (no per-layer
         # ``prefix`` plumbing through the Linear/MoE classes); instead every

--- a/gllm/runtime/model_runner.py
+++ b/gllm/runtime/model_runner.py
@@ -292,7 +292,7 @@ class ModelRunner:
             else maxp + maxd
         )
         
-        # Concurrent decode slots (SSM working pool, input buffers, CUDA
+        # Concurrent decode slots (SSM arena entries, input buffers, CUDA
         # graph capture). Bounded by ``maxd`` for all schedule methods.
         self.max_running_seqs = maxd
         
@@ -499,7 +499,7 @@ class ModelRunner:
         #
         #   * ``maxd`` — the decode batch is hard-capped at ``maxd`` (scheduler)
         #     and several device buffers (``InputData.block_table``,
-        #     ``slot_mapping``, the SSM working pool, ...) are sized at ``maxd``
+        #     ``slot_mapping``, SSM metadata, ...) are sized at ``maxd``
         #     rows.
         #   * ``max_num_batched_tokens`` — a captured decode graph of ``B``
         #     sequences writes ``B`` token-rows into the shared activation
@@ -749,12 +749,6 @@ class ModelRunner:
             vocab_size=self.model_loader.vocab_size,
             use_mla=self.model_loader.use_mla,
             ssm_cache_config=ssm_cache_config,
-            max_working_ssm_slots=self.max_running_seqs if ssm_cache_config else 0,
-            max_snapshot_ssm_slots=(
-                4 * self.max_running_seqs
-                if ssm_cache_config and self.enable_prefix_caching
-                else 0
-            ),
             max_running_seqs=self.max_running_seqs,
             # DeepSeek Sparse Attention (V3.2): non-zero => allocate a parallel
             # paged indexer key cache. 0 for every other model.
@@ -765,8 +759,8 @@ class ModelRunner:
             # requested (drives SM90 sparse decode); default bf16 + dense decode.
             mla_cache_fp8=(self.mla_cache_dtype == "fp8"),
             # MTP draft-chain length for hybrid GDN models: each running seq may
-            # borrow up to mtp_k transient checkpoint blocks from the shared SSM
-            # block pool during a verify step. 0 for non-MTP or non-hybrid.
+            # claim 1+mtp_k working/checkpoint entries from the cache arena.
+            # 0 for non-MTP or non-hybrid.
             # Recurrent-state prefix-cache granularity (tokens). Rounded to
             # whole pages by ``PrefixMemoryManager.init``.
             ssm_snapshot_stride_tokens=self.ssm_snapshot_stride_tokens,
@@ -3295,6 +3289,7 @@ class ModelRunner:
             with torch.cuda.graph(cuda_graph=g, pool=memory_pool, stream=stream):
                 self._draft_step_forward()
             self._draft_size_to_graph[bucket] = g
+
             # Also capture the sampled (rejection) draft step when enabled, so
             # sampling requests get a graphed draft too (Gumbel-max, graph-safe).
             if self._mtp_can_sample:

--- a/gllm/runtime/sequence.py
+++ b/gllm/runtime/sequence.py
@@ -85,7 +85,7 @@ class GenerationSequence:
         self.mm_contents = mm_contents
         # used to remove redundant token_ids
         self.to_compute_tokens = None
-        # SSM working-pool slot for hybrid (Mamba/GDN) models. ``None`` means
+        # SSM working arena slot for hybrid (Mamba/GDN) models. ``None`` means
         # either the model has no linear-attention layers or the scheduler
         # has not yet allocated a slot for this seq. The slot lives for the
         # whole lifetime of the request and is reset on preempt/free.
@@ -185,7 +185,7 @@ class GenerationSequence:
         # SSM state is recurrent, so preempting (= recomputing from scratch)
         # invalidates whatever was in the working slot. The actual slot is
         # released by the scheduler via ``MemoryManager.free_ssm_slot`` so
-        # that ``SSMSegment.free_working`` can also zero the tensors.
+        # that ``SSMSegment.free_block`` can also zero the tensors.
         self.ssm_state_slot = None
         self.ssm_block_table = None
         self.ssm_num_accepted = 1

--- a/gllm/scheduling/distributed.py
+++ b/gllm/scheduling/distributed.py
@@ -183,7 +183,7 @@ class SeqUpdate:
     # GDN forward resumes from the same column. ``None`` for non-MTP seqs.
     ssm_block_table: Optional[List[int]] = None
     ssm_num_accepted: int = 1
-    # Hybrid/SSM + prefix caching under PP>1 only: the snapshot-pool slot id
+    # Hybrid/SSM + prefix caching under PP>1 only: the snapshot arena slot id
     # assigned to each page in ``new_page_ids`` (``-1`` = no snapshot slot).
     # The follower mirrors these into its own ``page2ssm_snapshot`` table so its
     # ``_cal_ssm_metadata`` picks the same snapshot WRITE targets the driver
@@ -191,9 +191,9 @@ class SeqUpdate:
     # mirror (non-hybrid, no prefix cache, or no new pages).
     new_page_snap_slots: Optional[List[int]] = None
     # Hybrid/SSM + prefix caching under PP>1 only: when a prefix-cache hit
-    # restored recurrent state on the driver, the snapshot-pool slot to copy
+    # restored recurrent state on the driver, the snapshot arena slot to copy
     # into this seq's working slot BEFORE its next forward. The follower
-    # replays the identical ``copy_state`` on its own GDN-layer pools. A
+    # replays the identical ``copy_state`` on its own GDN-layer arena view. A
     # one-shot per-iteration signal (``None`` on every other iteration).
     ssm_restore_src_slot: Optional[int] = None
 

--- a/gllm/scheduling/scheduler.py
+++ b/gllm/scheduling/scheduler.py
@@ -479,11 +479,9 @@ class Scheduler:
         # re-queued after this round (no slot/page allocation, no ordering loss).
         deferred_disagg_seqs: List[GenerationSequence] = []
         prefill_batched_token_nums = 0
-        # Hybrid models (Qwen3.5 GDN) cap concurrency at the SSM working
-        # pool size; admitting more requests would assertion-crash inside
-        # ``IDAllocator.allocate``. ``ssm_segment`` is None for plain
-        # softmax-attn models, in which case the slot check below is a
-        # no-op.
+        # Hybrid models (Qwen3.5 GDN) claim working/checkpoint entries from the
+        # shared arena. ``ssm_segment`` is None for plain softmax-attention
+        # models, in which case the slot check below is a no-op.
         ssm_seg = getattr(self.memory_manager, "ssm_segment", None)
         # Cap the number of prefill seqs so the *combined* batch
         # (decode + prefill) never exceeds ``max_running_seqs`` rows, which
@@ -497,13 +495,15 @@ class Scheduler:
             and (max_seqs is None or len(prefill_batch) < max_seqs)
         ):
             seq = self.seqs_to_prefill.popleft()
-            # If this seq hasn't taken its SSM state block(s) yet AND the pool
-            # cannot fit a whole per-seq allocation (1 block, or 1+k for MTP),
-            # put the request back on the wait queue and stop admitting fresh
-            # prefills this round. In-flight prefill seqs keep their blocks.
+            # A new hybrid request atomically claims its whole per-seq state
+            # allocation (1 entry, or 1+k for MTP) from the shared arena.
             if ssm_seg is not None and seq.ssm_state_slot is None:
-                need = 1 + getattr(self.memory_manager, "mtp_k", 0)
-                if ssm_seg.num_free_blocks() < need:
+                # Claim recurrent-state extents before prefix lookup pins KV
+                # slots. Both cache types share one physical arena, so doing
+                # this in the opposite order can consume the last aligned SSM
+                # slots. The arena may reclaim evictable snapshots here; there
+                # is intentionally no fixed SSM reserve or admission watermark.
+                if not self.memory_manager.allocate_ssm_slot(seq):
                     self.seqs_to_prefill.appendleft(seq)
                     break
             if (
@@ -536,6 +536,7 @@ class Scheduler:
                 # Nothing prefillable this round; park and re-queue. No SSM slot
                 # / page allocation so freeing stays simple if it never runs.
                 deferred_disagg_seqs.append(seq)
+                self.memory_manager.free_ssm_slot(seq)
                 continue
             prefill_avail = len(seq) - seq.computed_token_num
             if gate_limit is not None:
@@ -545,7 +546,9 @@ class Scheduler:
             # the first schedule, freed when ``model_runner.free(seq)`` is
             # called from ``process_output`` / ``check_abort_seqs`` /
             # ``check_preempt``). No-op for non-hybrid models.
-            self.memory_manager.allocate_ssm_slot(seq)
+            if not self.memory_manager.allocate_ssm_slot(seq):
+                self.seqs_to_prefill.appendleft(seq)
+                break
             if prefill_avail <= prefill_token_budget:
                 seq.to_compute_token_num = prefill_avail
             else:
@@ -954,19 +957,42 @@ class OverlapScheduler(Scheduler):
             if not row:
                 raise RuntimeError("MTP async completion committed an empty row")
 
-            kept = 0
-            for token in row:
-                seq.append(int(token))
-                kept += 1
-                if kept > 1:
-                    seq.computed_token_num += 1
-                self.model_runner.register_decode_page_hash(seq, len(seq) - 1)
-                if seq.is_finish:
-                    break
+            # Commit the accepted prefix in one list operation.  Calling
+            # ``append``/``is_finish``/the page-boundary hook once per token is
+            # disproportionately expensive at large decode batches, while the
+            # stopping rule depends only on the first EOS and remaining output
+            # budget.
+            # An overlapped successor may already have launched when its
+            # predecessor reaches the output limit. Preserve the old finalize
+            # semantics in that case: commit exactly the first completed token
+            # and retire the request immediately afterwards.
+            remaining = max(
+                1, seq.output_len - (len(seq) - seq.raw_prompt_len)
+            )
+            kept = min(len(row), remaining)
+            if not seq.ignore_eos:
+                for idx, token in enumerate(row[:kept]):
+                    if int(token) in seq.finish_tokens:
+                        kept = idx + 1
+                        break
+            committed_tokens = [int(token) for token in row[:kept]]
+            append_start = len(seq.token_ids)
+            seq.token_ids.extend(committed_tokens)
+            seq.computed_token_num += max(kept - 1, 0)
+
+            # Prefix registration is a no-op away from page boundaries.  Jump
+            # directly between the boundaries crossed by this accepted span.
+            memory_manager = getattr(self.model_runner, "memory_manager", None)
+            page_size = getattr(memory_manager, "page_size", 1)
+            first_boundary = ((append_start // page_size) + 1) * page_size
+            for n_tokens in range(
+                first_boundary, append_start + kept + 1, page_size
+            ):
+                self.model_runner.register_decode_page_hash(seq, n_tokens - 1)
 
             if seq.computed_prompt:
                 ipc_package.act_schedule_ids.append(seq.seq_id)
-                ipc_package.next_tokens.append([int(t) for t in row[:kept]])
+                ipc_package.next_tokens.append(committed_tokens)
                 ipc_package.logprobs.append(None)
                 self._attach_prompt_logprobs(ipc_package, seq)
 

--- a/gllm/speculative/gpu_prep.py
+++ b/gllm/speculative/gpu_prep.py
@@ -128,14 +128,29 @@ class MtpGpuPrep:
         # --- persistent host staging (pinned; filled through numpy views) ---
         self._h_meta = torch.zeros((max_bs, META_W), dtype=torch.int64, device="cpu", pin_memory=True)
         self._h_meta_np = self._h_meta.numpy()
-        self._h_pt = torch.zeros((max_bs, max_blocks), dtype=torch.int32, device="cpu", pin_memory=True)
-        self._h_pt_np = self._h_pt.numpy()
+        # The active page-table width changes as requests grow. A rectangular
+        # ``[max_bs, max_blocks]`` allocation sliced as ``[:bucket, :cols]`` is
+        # not contiguous when ``cols < max_blocks``. Passing that view to
+        # ``copy_(..., non_blocking=True)`` makes PyTorch pack it through a
+        # pageable temporary, turning a nominally asynchronous H2D into a host
+        # synchronization. Keep the host payload densely packed instead, then
+        # scatter it into the stable-stride device table with a cheap D2D copy.
+        self._h_pt_packed = torch.zeros(
+            max_bs * max_blocks,
+            dtype=torch.int32,
+            device="cpu",
+            pin_memory=True,
+        )
+        self._h_pt_packed_np = self._h_pt_packed.numpy()
         self._h_bt = torch.zeros((max_bs, max(bt_width, 1)), dtype=torch.int32, device="cpu", pin_memory=True)
         self._h_bt_np = self._h_bt.numpy()
 
         # --- persistent device mirrors ---
         self._d_meta = torch.zeros((max_bs, META_W), dtype=torch.int64, device=device)
         self._d_pt = torch.zeros((max_bs, max_blocks), dtype=torch.int32, device=device)
+        self._d_pt_packed = torch.zeros(
+            max_bs * max_blocks, dtype=torch.int32, device=device
+        )
         self._d_bt = torch.zeros(
             (max_bs, max(bt_width, 1)), dtype=torch.int32, device=device
         )
@@ -226,10 +241,11 @@ class MtpGpuPrep:
         # id -- the attention kernels never look past ``ceil(seq_len/P)`` columns,
         # but matching ``_cal_block_table`` byte for byte keeps the assert honest
         # (and a stale page id in a debug dump is deeply confusing).
-        pt = self._h_pt_np
         lens = [len(s.page_table) for s in seqs]
         cols = max(max(lens, default=1), 1)
-        pt[:bucket, :cols] = 0
+        packed_elems = bucket * cols
+        pt = self._h_pt_packed_np[:packed_elems].reshape(bucket, cols)
+        pt[:, :] = 0
         for i, seq in enumerate(seqs):
             if lens[i]:
                 pt[i, : lens[i]] = seq.page_table
@@ -254,7 +270,10 @@ class MtpGpuPrep:
                 bt[nd:bucket, :w] = 0
 
         self._d_meta[:bucket].copy_(self._h_meta[:bucket], non_blocking=True)
-        self._d_pt[:bucket, :cols].copy_(self._h_pt[:bucket, :cols], non_blocking=True)
+        h_pt = self._h_pt_packed[:packed_elems].view(bucket, cols)
+        d_pt = self._d_pt_packed[:packed_elems].view(bucket, cols)
+        d_pt.copy_(h_pt, non_blocking=True)
+        self._d_pt[:bucket, :cols].copy_(d_pt)
         if self.bt_width:
             self._d_bt[:bucket].copy_(self._h_bt[:bucket], non_blocking=True)
 

--- a/gllm/workers/worker.py
+++ b/gllm/workers/worker.py
@@ -484,7 +484,7 @@ class Worker(TorchProfilerMixin):
                 page2snap[page_num] = snap if snap >= 0 else None
 
     def _apply_ssm_restores(self, seqs) -> None:
-        """Replay driver prefix-cache-hit restores on this stage's GDN pools.
+        """Replay driver prefix-cache-hit restores on this stage's GDN arena view.
 
         Each PP stage owns a different slice of the GDN layers, so the
         snapshot->working ``copy_state`` the driver ran on rank-0 must be redone

--- a/tests/test_cache_arena.py
+++ b/tests/test_cache_arena.py
@@ -1,0 +1,169 @@
+import torch
+
+from gllm.runtime.cache_arena import (
+    ArenaSlotAllocator,
+    CacheArena,
+    CacheLayout,
+    CacheTensorLayout,
+)
+
+
+def make_arena(num_pages=24, page_bytes=64):
+    return CacheArena(
+        torch.empty(num_pages * page_bytes, dtype=torch.uint8), page_bytes
+    )
+
+
+def test_registered_cache_types_reuse_the_same_physical_pages():
+    arena = make_arena()
+    arena.register_cache_type("kv", 64)
+    state = arena.register_cache_type("state", 150, prefer_high=True)
+
+    assert state.pages_per_slot == 3
+    assert arena.allocator.allocate("state", 2) == [7, 6]
+    assert arena.allocator.allocate("kv", 2) == [0, 1]
+    assert arena.allocator.num_used_physical_pages == 8
+
+    arena.allocator.free("state", [7])
+    # The exact bytes formerly used by state are now ordinary KV candidates.
+    allocated = arena.allocator.allocate("kv", 19)
+    assert {21, 22, 23}.issubset(allocated)
+
+
+def test_explicit_cache_retention_does_not_evict_its_own_contents():
+    arena = make_arena(4)
+    arena.register_cache_type("kv", 64)
+    evicted = []
+    arena.allocator.set_evictor("kv", evicted.append)
+
+    slot = arena.allocator.allocate("kv")[0]
+    assert evicted == [slot]
+    arena.allocator.free("kv", [slot])
+
+    # Explicit allocation means a prefix hit: the bytes were not overwritten
+    # while unpinned, so metadata/content must be retained.
+    assert arena.allocator.allocate("kv", slot=slot, retain=True) == [slot]
+    assert evicted == [slot]
+
+
+def test_overlapping_type_allocation_invalidates_stale_cache_metadata():
+    arena = make_arena(6)
+    arena.register_cache_type("kv", 64)
+    arena.register_cache_type("state", 150)
+    evicted = []
+    arena.allocator.set_evictor("kv", evicted.append)
+
+    pages = arena.allocator.allocate("kv", 3)
+    arena.allocator.free("kv", pages)
+    evicted.clear()
+    assert arena.allocator.allocate("state", slot=0) == [0]
+    assert evicted == [0, 1, 2]
+
+
+def test_pressure_reclaims_evictable_cache_without_a_fixed_limit():
+    arena = make_arena(6)
+    arena.register_cache_type("working", 150, prefer_high=True)
+    arena.register_cache_type("snapshot", 150, prefer_high=True)
+    snapshots = arena.allocator.allocate("snapshot", 2)
+    assert snapshots == [1, 0]
+
+    def reclaim_oldest():
+        if not snapshots:
+            return False
+        arena.allocator.free("snapshot", [snapshots.pop()])
+        return True
+
+    arena.allocator.set_reclaimer("snapshot", reclaim_oldest)
+    # No working slot is initially free. Allocation drives reclamation instead
+    # of relying on a pre-partition or snapshot-count watermark.
+    assert arena.allocator.allocate("working", 1) == [0]
+    assert snapshots == [1]
+
+
+def test_entry_views_have_stable_type_stride_and_shared_storage():
+    arena = make_arena(12)
+    state = arena.register_cache_type("state", 150)
+    view = arena.entry_view("state", torch.float32, (2, 3), entry_offset_bytes=8)
+
+    assert view.shape == (state.num_slots, 2, 3)
+    assert view.stride() == (48, 3, 1)
+    assert (
+        view.untyped_storage().data_ptr() == arena.backing.untyped_storage().data_ptr()
+    )
+
+
+def test_registered_cache_materializes_banks_with_one_slot_grid():
+    layout = CacheLayout(
+        "attention",
+        (
+            CacheTensorLayout("key", torch.bfloat16, (2, 4, 3)),
+            CacheTensorLayout("value", torch.float32, (2, 4, 5)),
+        ),
+    )
+    arena = make_arena(num_pages=20, page_bytes=layout.entry_bytes)
+    cache = arena.register_cache(layout)
+
+    assert cache.num_slots == 20
+    assert cache.tensor("key").shape == (20, 2, 4, 3)
+    assert cache.tensor("value").shape == (20, 2, 4, 5)
+    assert cache.tensor("key").stride(0) * 2 == layout.entry_bytes
+    assert cache.tensor("value").stride(0) * 4 == layout.entry_bytes
+    assert cache.tensor("key").untyped_storage().data_ptr() == (
+        cache.tensor("value").untyped_storage().data_ptr()
+    )
+
+    allocator = cache.slot_allocator()
+    slot = allocator.allocate()
+    cache.tensor("key")[slot].fill_(3)
+    cache.tensor("value")[slot].fill_(7)
+    assert torch.all(cache.tensor("key")[slot] == 3)
+    assert torch.all(cache.tensor("value")[slot] == 7)
+
+
+def test_id_allocator_facade_uses_logical_type_slots():
+    arena = make_arena(9)
+    arena.register_cache_type("kv", 64)
+    arena.register_cache_type("state", 150)
+    pages = ArenaSlotAllocator(arena, "kv")
+
+    page = pages.allocate()
+    assert not pages.is_free(page)
+    pages.free(page)
+    assert pages.is_free(page)
+
+
+def test_id_allocator_facade_coalesces_batch_free():
+    arena = make_arena(9)
+    arena.register_cache_type("kv", 64)
+    arena.register_cache_type("state", 150)
+    pages = ArenaSlotAllocator(arena, "kv")
+    allocated = [pages.allocate() for _ in range(6)]
+
+    updates = []
+    original = arena.allocator._update_candidates
+
+    def record_update(start, end, delta):
+        updates.append((start, end, delta))
+        original(start, end, delta)
+
+    arena.allocator._update_candidates = record_update
+    pages.free_many(allocated)
+
+    assert updates == [(0, 6, -1)]
+    assert all(pages.is_free(page) for page in allocated)
+
+
+def test_allocator_coalesces_batch_claim():
+    arena = make_arena(9)
+    arena.register_cache_type("kv", 64)
+    arena.register_cache_type("state", 150)
+    updates = []
+    original = arena.allocator._update_candidates
+
+    def record_update(start, end, delta):
+        updates.append((start, end, delta))
+        original(start, end, delta)
+
+    arena.allocator._update_candidates = record_update
+    assert arena.allocator.allocate("kv", 6) == list(range(6))
+    assert updates == [(0, 6, 1)]

--- a/tests/test_chunk_gdn_strided_state.py
+++ b/tests/test_chunk_gdn_strided_state.py
@@ -1,0 +1,57 @@
+import pytest
+import torch
+
+from gllm.layers.ops.fla import chunk_gated_delta_rule
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_chunk_gdn_updates_arena_strided_state_in_place():
+    torch.manual_seed(1)
+    dtype = torch.bfloat16
+    nseq, heads, key_dim, value_dim, seq_len = 2, 2, 16, 16, 64
+    total = nseq * seq_len
+    q = torch.randn(1, total, heads, key_dim, device="cuda", dtype=dtype)
+    k = torch.randn_like(q)
+    v = torch.randn(1, total, heads, value_dim, device="cuda", dtype=dtype)
+    g = torch.nn.functional.logsigmoid(
+        torch.randn(1, total, heads, device="cuda", dtype=dtype)
+    )
+    beta = torch.sigmoid(torch.randn_like(g))
+    cu_seqlens = torch.tensor([0, seq_len, total], device="cuda", dtype=torch.int32)
+    state_indices = torch.tensor([1, 3], device="cuda", dtype=torch.int32)
+
+    compact = torch.zeros(
+        5, heads, value_dim, key_dim, device="cuda", dtype=dtype
+    )
+    compact[1].normal_()
+    compact[3].normal_()
+    padded_stride = heads * value_dim * key_dim + 97
+    backing = torch.zeros(5 * padded_stride, device="cuda", dtype=dtype)
+    arena_state = torch.as_strided(
+        backing,
+        compact.shape,
+        (padded_stride, value_dim * key_dim, key_dim, 1),
+    )
+    arena_state.copy_(compact)
+    reference_state = compact.clone()
+
+    reference_out = chunk_gated_delta_rule(
+        q, k, v, g, beta,
+        initial_state=reference_state,
+        initial_state_indices=state_indices,
+        cu_seqlens=cu_seqlens,
+        use_qk_l2norm_in_kernel=True,
+    )[0]
+    arena_out = chunk_gated_delta_rule(
+        q, k, v, g, beta,
+        initial_state=arena_state,
+        initial_state_indices=state_indices,
+        cu_seqlens=cu_seqlens,
+        use_qk_l2norm_in_kernel=True,
+    )[0]
+
+    torch.cuda.synchronize()
+    assert torch.equal(reference_out, arena_out)
+    assert torch.equal(
+        reference_state[state_indices.long()], arena_state[state_indices.long()]
+    )

--- a/tests/test_flashinfer_trtllm_moe.py
+++ b/tests/test_flashinfer_trtllm_moe.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from gllm.layers.moe.flashinfer_trtllm import (
+    bf16_moe_support_reason,
+    convert_bf16_moe_weights,
+)
+
+
+def make_layer(**overrides):
+    values = {
+        "w13_weight": torch.empty(2, 256, 128, dtype=torch.bfloat16),
+        "w2_weight": torch.empty(2, 128, 128, dtype=torch.bfloat16),
+        "global_num_experts": 2,
+        "activation": "silu",
+        "apply_router_weight_on_input": False,
+        "scoring_func": "softmax",
+        "use_grouped_topk": False,
+        "e_score_correction_bias": None,
+        "intermediate_size_per_partition": 128,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_support_reason_accepts_sm100_bf16(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda: (10, 0))
+    assert bf16_moe_support_reason(make_layer()) is None
+
+
+@pytest.mark.parametrize(
+    ("override", "reason"),
+    [
+        ({"activation": "gelu"}, "activation"),
+        ({"scoring_func": "sigmoid"}, "scoring_func"),
+        ({"use_grouped_topk": True}, "grouped"),
+        ({"intermediate_size_per_partition": 96}, "aligned"),
+    ],
+)
+def test_support_reason_rejects_unsupported_routes(monkeypatch, override, reason):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda: (10, 0))
+    assert reason in bf16_moe_support_reason(make_layer(**override))
+
+
+def test_support_reason_falls_back_outside_sm100(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda: (9, 0))
+    assert "SM100" in bf16_moe_support_reason(make_layer())
+
+
+def test_block_layout_preserves_storage_size():
+    w13 = torch.arange(2 * 256 * 128, dtype=torch.float32).to(torch.bfloat16)
+    w13 = w13.view(2, 256, 128)
+    w2 = torch.arange(2 * 128 * 128, dtype=torch.float32).to(torch.bfloat16)
+    w2 = w2.view(2, 128, 128)
+
+    converted_w13, converted_w2 = convert_bf16_moe_weights(w13, w2)
+
+    assert converted_w13.numel() == w13.numel()
+    assert converted_w2.numel() == w2.numel()
+    assert converted_w13.shape == (2, 2, 256, 64)
+    assert converted_w2.shape == (2, 2, 128, 64)
+    assert converted_w13.is_contiguous()
+    assert converted_w2.is_contiguous()

--- a/tests/test_gemma_rmsnorm_exact.py
+++ b/tests/test_gemma_rmsnorm_exact.py
@@ -1,0 +1,46 @@
+"""Exactness checks for the launch-reduced Gemma RMSNorm path."""
+
+import torch
+
+from gllm.layers.ops.gemma_rmsnorm import gemma_rms_norm_reference_reduction
+
+
+def _reference(out, x, weight, eps):
+    x_fp32 = x.float()
+    normalized = x_fp32 * torch.rsqrt(
+        x_fp32.square().mean(dim=-1, keepdim=True) + eps
+    )
+    out.copy_((normalized * (weight.float() + 1.0)).to(x.dtype))
+
+
+def main():
+    torch.manual_seed(23)
+    for rows, width in ((1, 128), (127, 128), (128, 2048), (513, 2048)):
+        x = torch.randn(rows, width, device="cuda", dtype=torch.bfloat16)
+        for weight_dtype in (torch.bfloat16, torch.float32):
+            weight = (
+                torch.randn(width, device="cuda", dtype=weight_dtype) * 0.05
+            )
+            expected = torch.empty_like(x)
+            actual = torch.empty_like(x)
+            _reference(expected, x, weight, 1e-6)
+            gemma_rms_norm_reference_reduction(actual, x, weight, 1e-6)
+            assert torch.equal(actual, expected), (rows, width, weight_dtype)
+
+            residual = torch.randn_like(x)
+            expected_residual = residual.clone()
+            expected_residual.add_(x)
+            _reference(expected, expected_residual, weight, 1e-6)
+            actual_residual = residual.clone()
+            actual_residual.add_(x)
+            gemma_rms_norm_reference_reduction(
+                actual, actual_residual, weight, 1e-6
+            )
+            assert torch.equal(actual_residual, expected_residual)
+            assert torch.equal(actual, expected), (rows, width, weight_dtype)
+
+    print("Gemma RMSNorm optimized path exactly matches the FP32 reference")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_memory_manager_arena.py
+++ b/tests/test_memory_manager_arena.py
@@ -1,0 +1,180 @@
+import pytest
+import torch
+
+from gllm.layers.ops.triton_decode_attention import decode_attention_fwd
+from gllm.runtime.cache_arena import CacheArena
+from gllm.runtime.memory_manager import MemoryManager, SSMSegment, SSMCacheConfig, Segment
+
+
+def _arena_for(layout, slots=12):
+    arena = CacheArena(
+        torch.empty(slots * layout.entry_bytes, dtype=torch.uint8),
+        physical_page_bytes=layout.entry_bytes,
+    )
+    return arena, arena.register_cache(layout)
+
+
+def test_explicit_kv_segment_uses_registered_cache_only():
+    manager = MemoryManager(
+        0.9,
+        num_layers=3,
+        dtype=torch.bfloat16,
+        page_size=4,
+        kv_head_num=2,
+        kv_head_dim=8,
+        vocab_size=32,
+    )
+    layout = manager._kv_cache_layout()
+    arena, cache = _arena_for(layout)
+    segment = Segment(3, 4, 2, 8, False, cache)
+
+    assert tuple(tensor.name for tensor in layout.tensors) == ("key", "value")
+    assert segment.k_cache[1].shape == (12, 4, 2, 8)
+    assert segment.v_cache[1].shape == (12, 4, 2, 8)
+    assert segment.k_cache[1].untyped_storage().data_ptr() == (
+        arena.backing.untyped_storage().data_ptr()
+    )
+    page = segment.allocate()
+    segment.k_cache[1][page].fill_(2)
+    segment.v_cache[1][page].fill_(3)
+    assert torch.all(cache.tensor("key")[page, 1] == 2)
+    assert torch.all(cache.tensor("value")[page, 1] == 3)
+    segment.free(page)
+
+
+def test_mla_and_index_banks_share_one_registered_page_lifetime():
+    manager = MemoryManager(
+        0.9,
+        num_layers=2,
+        dtype=torch.bfloat16,
+        page_size=64,
+        kv_head_num=1,
+        kv_head_dim=576,
+        vocab_size=32,
+        use_mla=True,
+        index_head_dim=128,
+        qk_rope_head_dim=64,
+        mla_cache_fp8=True,
+    )
+    layout = manager._kv_cache_layout()
+    arena, cache = _arena_for(layout, slots=4)
+    segment = Segment(
+        2,
+        64,
+        1,
+        576,
+        True,
+        cache,
+        index_head_dim=128,
+        qk_rope_head_dim=64,
+        mla_cache_fp8=True,
+    )
+
+    assert tuple(tensor.name for tensor in layout.tensors) == (
+        "mla",
+        "index_key",
+        "index_key_fp8",
+    )
+    assert segment.kv_cache[0].shape == (4, 64, 1, 656)
+    assert segment.index_k_cache[0].shape == (4, 64, 128)
+    assert segment.index_k_fp8_cache[0].shape == (4, 64 * 132)
+    assert segment.index_fp8_bytes == 132
+    assert manager.get_sizeof_KV_per_page() == layout.entry_bytes
+    assert all(
+        tensor.untyped_storage().data_ptr()
+        == arena.backing.untyped_storage().data_ptr()
+        for tensor in (
+            segment.kv_cache[0],
+            segment.index_k_cache[0],
+            segment.index_k_fp8_cache[0],
+        )
+    )
+
+
+def test_ssm_segment_consumes_registered_working_and_snapshot_layouts():
+    cfg = SSMCacheConfig(
+        num_layers=2,
+        conv_dim=12,
+        conv_kernel=4,
+        num_v_heads=2,
+        head_v_dim=4,
+        head_k_dim=4,
+        dtype=torch.float32,
+        conv_state_dtype=torch.bfloat16,
+    )
+    manager = MemoryManager(
+        0.9,
+        num_layers=2,
+        dtype=torch.bfloat16,
+        page_size=4,
+        kv_head_num=2,
+        kv_head_dim=8,
+        vocab_size=32,
+        ssm_cache_config=cfg,
+    )
+    kv_layout = manager._kv_cache_layout()
+    arena = CacheArena(
+        torch.empty(24 * kv_layout.entry_bytes, dtype=torch.uint8),
+        physical_page_bytes=kv_layout.entry_bytes,
+    )
+    arena.register_cache(kv_layout)
+    working = arena.register_cache(manager._ssm_cache_layout("ssm_state"))
+    snapshot = arena.register_cache(manager._ssm_cache_layout("ssm_snapshot"))
+    segment = SSMSegment(cfg, state_cache=working, snapshot_cache=snapshot)
+
+    assert segment.conv_state.shape == (2, working.num_slots, 12, 3)
+    assert segment.temporal_state.shape == (2, working.num_slots, 2, 4, 4)
+    blocks = segment.allocate_block_table(2)
+    assert blocks is not None
+    segment.free_block_table(blocks)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_triton_mla_decode_honors_arena_block_stride():
+    torch.manual_seed(0)
+    batch, heads, dim, page_size, num_blocks, num_splits = 3, 8, 32, 16, 12, 4
+    q = torch.randn(batch, heads, dim, device="cuda", dtype=torch.bfloat16)
+    key_backing = torch.randn(
+        num_blocks, 2, page_size, 1, dim, device="cuda", dtype=torch.bfloat16
+    )
+    value_backing = torch.randn_like(key_backing)
+    key_strided = key_backing[:, 0]
+    value_strided = value_backing[:, 0]
+    block_table = torch.tensor(
+        [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]],
+        device="cuda",
+        dtype=torch.int32,
+    )
+    seq_lens = torch.tensor([61, 55, 48], device="cuda", dtype=torch.int32)
+
+    def run(key, value):
+        output = torch.empty_like(q)
+        lse = torch.empty(batch, heads, device="cuda", dtype=torch.bfloat16)
+        logits = torch.empty(
+            batch,
+            heads,
+            num_splits,
+            dim + 1,
+            device="cuda",
+            dtype=torch.float32,
+        )
+        decode_attention_fwd(
+            q,
+            key,
+            value,
+            output,
+            lse,
+            block_table,
+            seq_lens,
+            logits,
+            num_splits,
+            dim**-0.5,
+            page_size,
+        )
+        return output, lse
+
+    contiguous = run(key_strided.contiguous(), value_strided.contiguous())
+    strided = run(key_strided, value_strided)
+    torch.cuda.synchronize()
+    assert torch.equal(contiguous[0], strided[0])
+    assert torch.equal(contiguous[1], strided[1])

--- a/tests/test_ssm_snapshot_publication.py
+++ b/tests/test_ssm_snapshot_publication.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+
+import torch
+
+import gllm.runtime.input_data as input_data_module
+from gllm.runtime.input_data import InputData
+from gllm.runtime.sequence import GenerationSequence
+
+
+class _SnapshotSegment:
+    def __init__(self):
+        self.calls = []
+        self.page2ssm_snapshot = [None] * 32
+        self.page2ssm_snapshot_valid = [False] * 32
+
+    def reserve_ssm_snapshot(self, page_num, end_tokens):
+        self.calls.append((page_num, end_tokens))
+        self.page2ssm_snapshot[page_num] = 7
+        return 7
+
+
+def test_overlap_snapshot_is_reserved_and_published_at_launch(monkeypatch):
+    monkeypatch.setattr(input_data_module, "get_pp_size", lambda: 1)
+    segment = _SnapshotSegment()
+    manager = SimpleNamespace(
+        page_size=16,
+        use_mla=False,
+        use_ssm_cache=True,
+        segment=segment,
+    )
+    data = InputData(False, manager, max_seq_length=512)
+    seq = GenerationSequence(1, [1] * 256, [])
+    seq.ssm_state_slot = 3
+    seq.to_compute_token_num = 256
+    seq.page_table = list(range(16))
+
+    data._cal_ssm_metadata([seq])
+
+    # Merely prebuilding an overlap batch must not mutate snapshot ownership or
+    # make zero-initialized storage visible to a later prefix-cache lookup.
+    assert segment.calls == []
+    assert data.ssm_snapshot_write_slot_per_seq_cpu.tolist() == [-1]
+    assert not any(segment.page2ssm_snapshot_valid)
+
+    data._materialize_ssm_snapshot_targets()
+    assert segment.calls == [(15, 256)]
+    assert data.ssm_snapshot_write_slot_per_seq_cpu.tolist() == [7]
+    assert not any(segment.page2ssm_snapshot_valid)
+
+    # Publication is a separate post-enqueue transition.
+    data.mark_ssm_snapshot_writes_enqueued()
+    assert segment.page2ssm_snapshot_valid[15]
+    assert data._ssm_snapshot_writes_pending == ()


### PR DESCRIPTION
- allocate KV cache, SSM state, and snapshots from a shared typed arena
- add FlashInfer TRT-LLM BF16 MoE with Triton fallback
- reduce MTP metadata preparation and CPU-GPU synchronization overhead
- support strided cache layouts in attention and recurrent kernels
- add correctness tests for arena allocation, MoE, GDN, and SSM snapshots