### PR TITLE
Add current OpenAI protocol and Responses API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ uv pip install "git+https://github.com/gty111/gLLM.git"
 
 ### Launch OpenAI-Compatible Server (Intra-node)
 
+The server implements current OpenAI-compatible `/v1/chat/completions`,
+`/v1/completions`, `/v1/models`, and the core text, image/file-input, and
+function-tool subset of `/v1/responses`. Responses image inputs accept URLs and
+data URLs. File inputs accept URLs or Base64 data for images, text/code, and CSV
+files; PDF inputs and `file_id` references are not yet supported.
+Unsupported hosted features return an OpenAI-style
+`unsupported_parameter` error instead of being silently ignored.
+
 ```bash
 # To see the description of args, run 'python -m gllm.entrypoints.api_server -h'
 python -m gllm.entrypoints.api_server --model-path $MODEL_PATH

--- a/gllm/entrypoints/api_server.py
+++ b/gllm/entrypoints/api_server.py
@@ -2,22 +2,27 @@ import argparse
 import asyncio
 import traceback
 from http import HTTPStatus
+from pathlib import Path
+from typing import Optional
 
 import fastapi
 import uvicorn
 from fastapi import APIRouter, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, StreamingResponse
 from logger import logger
 
-from gllm.entrypoints import cli_args
 from gllm.engine.async_llm import AsyncLLM
+from gllm.entrypoints import cli_args
 from gllm.entrypoints.protocol import (
     ChatCompletionRequest,
     CompletionRequest,
+    ErrorDetail,
     ErrorResponse,
     ModelCard,
     ModelList,
     ModelPermission,
+    ResponseRequest,
 )
 from gllm.entrypoints.serving_chat import (
     chat_completion_generator,
@@ -26,6 +31,11 @@ from gllm.entrypoints.serving_chat import (
 from gllm.entrypoints.serving_completions import (
     completion_generator,
     completion_stream_generator,
+)
+from gllm.entrypoints.serving_responses import (
+    make_chat_request,
+    response_completion_generator,
+    response_stream_generator,
 )
 from gllm.tokenizers.tool_parsers import get_tool_parser
 from gllm.utils import find_free_ports, make_async
@@ -37,6 +47,132 @@ llm: AsyncLLM = None
 # tool-call markup into structured ``tool_calls``. ``None`` => model has no
 # known tool-call format, raw text passes through as content.
 tool_parser = None
+
+
+def _openai_error(
+    message: str,
+    status_code: int = 400,
+    *,
+    error_type: str = "invalid_request_error",
+    param: Optional[str] = None,
+    code: Optional[str] = None,
+):
+    body = ErrorResponse(
+        error=ErrorDetail(message=message, type=error_type, param=param, code=code)
+    )
+    return JSONResponse(status_code=status_code, content=body.model_dump())
+
+
+def _served_model_ids():
+    """Return stable aliases for the one checkpoint loaded by this server."""
+    model_path = str(getattr(llm, "model_path", ""))
+    ids = {model_path}
+    parts = Path(model_path).parts
+    for part in parts:
+        if part.startswith("models--"):
+            ids.add(part.removeprefix("models--").replace("--", "/"))
+    if model_path:
+        ids.add(Path(model_path).name)
+    return {model_id for model_id in ids if model_id}
+
+
+def _validate_model(model: str):
+    if model not in _served_model_ids():
+        return _openai_error(
+            f"The model `{model}` does not exist or is not loaded by this server.",
+            404,
+            error_type="invalid_request_error",
+            param="model",
+            code="model_not_found",
+        )
+    return None
+
+
+def _public_model_id():
+    aliases = [
+        model_id
+        for model_id in _served_model_ids()
+        if not model_id.startswith("/") and "/" in model_id
+    ]
+    return min(aliases, key=len) if aliases else str(llm.model_path)
+
+
+def _unsupported(param: str, detail: Optional[str] = None):
+    message = detail or f"The parameter `{param}` is not supported by this server."
+    return _openai_error(message, param=param, code="unsupported_parameter")
+
+
+def _validate_chat_capabilities(request: ChatCompletionRequest):
+    model_error = _validate_model(request.model)
+    if model_error:
+        return model_error
+    checks = [
+        (request.n not in (None, 1), "n"),
+        (request.frequency_penalty not in (None, 0, 0.0), "frequency_penalty"),
+        (request.presence_penalty not in (None, 0, 0.0), "presence_penalty"),
+        (request.logit_bias is not None, "logit_bias"),
+        (request.seed is not None, "seed"),
+        (bool(request.stop), "stop"),
+        (request.store is True, "store"),
+        (request.audio is not None, "audio"),
+        (bool(request.modalities and "audio" in request.modalities), "modalities"),
+        (request.moderation is not None, "moderation"),
+        (request.prediction is not None, "prediction"),
+        (request.prompt_cache_options is not None, "prompt_cache_options"),
+        (request.web_search_options is not None, "web_search_options"),
+    ]
+    for condition, param in checks:
+        if condition:
+            return _unsupported(param)
+    if request.response_format is not None and request.response_format.type != "text":
+        return _unsupported(
+            "response_format",
+            "Structured output response formats are not wired to this runtime yet.",
+        )
+    if request.tools:
+        for tool in request.tools:
+            if tool.type != "function":
+                return _unsupported("tools", "Only function tools are supported.")
+    choice = request.tool_choice
+    if choice not in (None, "none", "auto"):
+        return _unsupported(
+            "tool_choice",
+            "This runtime supports tool_choice='none' and 'auto'; forced and allowed tool choices are not enforceable by the loaded model.",
+        )
+    return None
+
+
+def _validate_response_capabilities(request: ResponseRequest):
+    model_error = _validate_model(request.model)
+    if model_error:
+        return model_error
+    checks = [
+        (request.background is True, "background"),
+        (request.conversation is not None, "conversation"),
+        (bool(request.include), "include"),
+        (request.max_tool_calls is not None, "max_tool_calls"),
+        (request.moderation is not None, "moderation"),
+        (request.previous_response_id is not None, "previous_response_id"),
+        (request.prompt is not None, "prompt"),
+        (request.prompt_cache_options is not None, "prompt_cache_options"),
+        (request.store is True, "store"),
+        (request.top_logprobs is not None, "top_logprobs"),
+        (request.truncation == "auto", "truncation"),
+    ]
+    for condition, param in checks:
+        if condition:
+            return _unsupported(param)
+    text_format = (request.text or {}).get("format") or {"type": "text"}
+    if text_format.get("type", "text") != "text":
+        return _unsupported(
+            "text.format", "Structured Responses output is not wired yet."
+        )
+    if request.tool_choice not in (None, "none", "auto"):
+        return _unsupported(
+            "tool_choice",
+            "This runtime supports tool_choice='none' and 'auto' for Responses.",
+        )
+    return None
 
 
 @router.get("/health")
@@ -51,25 +187,44 @@ async def version():
 
 @router.get("/server_info")
 async def server_info():
-    return JSONResponse(content={
-        "model": llm.model_path if llm else "",
-        "version": "0.0.7",
-        "status": "running",
-    })
+    return JSONResponse(
+        content={
+            "model": llm.model_path if llm else "",
+            "version": "0.0.7",
+            "status": "running",
+        }
+    )
 
 
 @router.get("/v1/models")
 async def show_available_models():
+    model_id = _public_model_id()
     models = ModelList(
-        data=[ModelCard(id=llm.model_path, root=llm.model_path,
-                        max_model_len=llm.model_max_length,
-                        permission=[ModelPermission()])]
+        data=[
+            ModelCard(
+                id=model_id,
+                root=model_id,
+                max_model_len=llm.model_max_length,
+                permission=[ModelPermission()],
+            )
+        ]
     )
     return JSONResponse(content=models.model_dump())
 
 
 @router.post("/v1/chat/completions")
 async def create_chat_completion(request: ChatCompletionRequest, raw_request: Request):
+    capability_error = _validate_chat_capabilities(request)
+    if capability_error:
+        return capability_error
+
+    effective_tools = request.tools if request.tool_choice != "none" else None
+    chat_template_kwargs = dict(request.chat_template_kwargs or {})
+    if request.reasoning_effort == "none":
+        # Qwen and other reasoning templates commonly expose one or both names.
+        chat_template_kwargs.setdefault("enable_thinking", False)
+        chat_template_kwargs.setdefault("thinking", False)
+
     mm_contents = await make_async(llm.model_runner.extract_modify_mm)(request.messages)
     # Encoder-disaggregation frontend (design §3.1 / §5.4): tokenize the *text
     # only* into a skeleton (one sentinel per item) and ship the raw items to
@@ -83,7 +238,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             request.messages
         )
         token_ids = await make_async(llm.model_runner.encode_skeleton)(
-            request.messages, chat_template_kwargs=request.chat_template_kwargs
+            request.messages, chat_template_kwargs=chat_template_kwargs or None
         )
         mm_contents = None  # LM holds no pixels; embeddings arrive over NIXL
     else:
@@ -91,13 +246,16 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             request.messages,
             chat=True,
             has_mm=mm_contents is not None,
-            chat_template_kwargs=request.chat_template_kwargs,
+            chat_template_kwargs=chat_template_kwargs or None,
             # Serialize the pydantic tool schemas to plain dicts; the chat
             # templates (and Kimi's ``encode_tools_to_typescript_style``)
             # expect JSON-like dicts, not pydantic models.
             tools=(
-                [t.model_dump(exclude_none=True) for t in request.tools]
-                if request.tools
+                [
+                    t.model_dump(exclude_none=True, by_alias=True)
+                    for t in effective_tools
+                ]
+                if effective_tools
                 else None
             ),
         )
@@ -141,21 +299,110 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             num_prompt_logprobs=num_prompt_logprobs,
         )
     else:
-        return ErrorResponse(
-            message="seq length exceeds max model length",
-            type="BadRequestError",
-            code=HTTPStatus.BAD_REQUEST.value,
+        return _openai_error(
+            "This request exceeds the model's maximum context length.",
+            HTTPStatus.BAD_REQUEST.value,
+            param="messages",
+            code="context_length_exceeded",
         )
     if request.stream:
         generator = chat_completion_stream_generator(stream, request, tool_parser)
         return StreamingResponse(content=generator, media_type="text/event-stream")
     else:
         generator = await chat_completion_generator(stream, request, tool_parser)
-        return JSONResponse(content=generator.model_dump())
+        return JSONResponse(content=generator.model_dump(exclude_none=True))
+
+
+@router.post("/v1/responses")
+async def create_response(request: ResponseRequest, raw_request: Request):
+    capability_error = _validate_response_capabilities(request)
+    if capability_error:
+        return capability_error
+    try:
+        # File URLs involve blocking I/O; keep them off the FastAPI event loop
+        # while building the native text/image message.
+        chat_request = await make_async(make_chat_request)(request)
+    except ValueError as exc:
+        param, message = exc.args if len(exc.args) == 2 else ("input", str(exc))
+        return _unsupported(param, message)
+
+    effective_tools = chat_request.tools if chat_request.tool_choice != "none" else None
+    chat_template_kwargs = {}
+    if chat_request.reasoning_effort == "none":
+        chat_template_kwargs.update(enable_thinking=False, thinking=False)
+    try:
+        mm_contents = await make_async(llm.model_runner.extract_modify_mm)(
+            chat_request.messages
+        )
+        if mm_contents is not None and not llm.model_runner.use_mm:
+            return _unsupported(
+                "input",
+                "The loaded model does not support image inputs.",
+            )
+        disagg = getattr(llm, "is_disagg_lm", False)
+        mm_items = None
+        if disagg and mm_contents is not None:
+            mm_items = await make_async(llm.model_runner.extract_mm_items_ordered)(
+                chat_request.messages
+            )
+            token_ids = await make_async(llm.model_runner.encode_skeleton)(
+                chat_request.messages,
+                chat_template_kwargs=chat_template_kwargs or None,
+            )
+            mm_contents = None
+        else:
+            token_ids = await make_async(llm.model_runner.encode)(
+                chat_request.messages,
+                chat=True,
+                has_mm=mm_contents is not None,
+                chat_template_kwargs=chat_template_kwargs or None,
+                tools=(
+                    [
+                        tool.model_dump(exclude_none=True, by_alias=True)
+                        for tool in effective_tools
+                    ]
+                    if effective_tools
+                    else None
+                ),
+            )
+    except (TypeError, ValueError) as exc:
+        return _openai_error(str(exc), param="input", code="invalid_input")
+
+    if not llm.check_seq_length(token_ids, request.max_output_tokens):
+        return _openai_error(
+            "This request exceeds the model's maximum context length.",
+            param="input",
+            code="context_length_exceeded",
+        )
+    stream = await llm.add_requests_async(
+        raw_request,
+        token_ids,
+        request.max_output_tokens,
+        False,
+        request.temperature,
+        request.top_p,
+        None,
+        None,
+        mm_contents,
+        mm_items,
+        dp_index=getattr(raw_request.app.state, "dp_index", None),
+    )
+    if request.stream:
+        generator = response_stream_generator(
+            stream, request, chat_request, tool_parser
+        )
+        return StreamingResponse(content=generator, media_type="text/event-stream")
+    response = await response_completion_generator(
+        stream, request, chat_request, tool_parser
+    )
+    return JSONResponse(content=response)
 
 
 @router.post("/v1/completions")
 async def create_completion(request: CompletionRequest, raw_request: Request):
+    model_error = _validate_model(request.model)
+    if model_error:
+        return model_error
     token_ids = await make_async(llm.model_runner.encode)(request.prompt)
     # OpenAI completions ``logprobs`` is an int: the number of top alternatives
     # to report (the sampled token's logprob is always included). ``None`` /
@@ -183,10 +430,11 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             num_prompt_logprobs=num_prompt_logprobs,
         )
     else:
-        return ErrorResponse(
-            message="seq length exceeds max model length",
-            type="BadRequestError",
-            code=HTTPStatus.BAD_REQUEST.value,
+        return _openai_error(
+            "This request exceeds the model's maximum context length.",
+            HTTPStatus.BAD_REQUEST.value,
+            param="prompt",
+            code="context_length_exceeded",
         )
     if request.stream:
         generator = completion_stream_generator(stream, request)
@@ -212,6 +460,30 @@ def _build_app(dp_index=None):
     """One FastAPI app. ``dp_index`` (via ``app.state``) pins every request that
     arrives on this app to a specific DP replica; ``None`` = round-robin."""
     app = fastapi.FastAPI()
+
+    @app.exception_handler(RequestValidationError)
+    async def openai_validation_error_handler(_, exc: RequestValidationError):
+        first = exc.errors()[0] if exc.errors() else {}
+        location = first.get("loc", ())
+        param = ".".join(str(part) for part in location if part != "body") or None
+        message = first.get("msg", "Invalid request")
+        return _openai_error(
+            message,
+            HTTPStatus.BAD_REQUEST.value,
+            param=param,
+            code="invalid_request",
+        )
+
+    @app.exception_handler(Exception)
+    async def openai_internal_error_handler(_, exc: Exception):
+        logger.exception("Unhandled API request error", exc_info=exc)
+        return _openai_error(
+            "Internal server error",
+            HTTPStatus.INTERNAL_SERVER_ERROR.value,
+            error_type="server_error",
+            code="internal_error",
+        )
+
     app.include_router(router)
     app.state.dp_index = dp_index
     return app
@@ -223,9 +495,9 @@ def _endpoint_ports(args):
     dp_size = getattr(args, "dp", 1)
     if getattr(args, "endpoint_per_dp_ports", None):
         ports = [int(p) for p in args.endpoint_per_dp_ports.split(",") if p != ""]
-        assert len(ports) == dp_size, (
-            f"--endpoint-per-dp-ports has {len(ports)} ports but dp_size={dp_size}"
-        )
+        assert (
+            len(ports) == dp_size
+        ), f"--endpoint-per-dp-ports has {len(ports)} ports but dp_size={dp_size}"
         return ports
     return find_free_ports(dp_size, args.host)
 
@@ -353,7 +625,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--ranks", type=str, help="Specify the ranks of worker like 0,1", default=None
     )
-    # MultiModal 
+    # MultiModal
     return parser
 
 

--- a/gllm/entrypoints/protocol.py
+++ b/gllm/entrypoints/protocol.py
@@ -55,12 +55,17 @@ class OpenAIBaseModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class ErrorResponse(OpenAIBaseModel):
-    object: str = "error"
+class ErrorDetail(OpenAIBaseModel):
     message: str
     type: str
     param: Optional[str] = None
-    code: int
+    code: Optional[Union[str, int]] = None
+
+
+class ErrorResponse(OpenAIBaseModel):
+    """OpenAI error envelope returned for every HTTP/API error."""
+
+    error: ErrorDetail
 
 
 class ModelPermission(OpenAIBaseModel):
@@ -98,6 +103,8 @@ class UsageInfo(OpenAIBaseModel):
     prompt_tokens: int = 0
     total_tokens: int = 0
     completion_tokens: Optional[int] = 0
+    prompt_tokens_details: Optional[Dict[str, int]] = None
+    completion_tokens_details: Optional[Dict[str, int]] = None
 
 
 class StructuralTag(OpenAIBaseModel):
@@ -117,27 +124,48 @@ class StructuralTagResponseFormat(OpenAIBaseModel):
 
 
 class ResponseFormat(OpenAIBaseModel):
-    # type must be "json_object" or "text"
     type: Literal["text", "json_object"]
 
 
-AnyResponseFormat = Union[ResponseFormat, StructuralTagResponseFormat]
+class JSONSchemaDefinition(OpenAIBaseModel):
+    name: str
+    description: Optional[str] = None
+    schema_: Dict[str, Any] = Field(alias="schema")
+    strict: Optional[bool] = None
+
+
+class JSONSchemaResponseFormat(OpenAIBaseModel):
+    type: Literal["json_schema"]
+    json_schema: JSONSchemaDefinition
+
+
+AnyResponseFormat = Union[
+    ResponseFormat, JSONSchemaResponseFormat, StructuralTagResponseFormat
+]
 
 
 class StreamOptions(OpenAIBaseModel):
-    include_usage: Optional[bool] = True
-    continuous_usage_stats: Optional[bool] = True
+    include_usage: Optional[bool] = False
+    include_obfuscation: Optional[bool] = None
+    # gLLM extension retained for backwards compatibility.
+    continuous_usage_stats: Optional[bool] = False
 
 
 class FunctionDefinition(OpenAIBaseModel):
     name: str
     description: Optional[str] = None
     parameters: Optional[Dict[str, Any]] = None
+    strict: Optional[bool] = None
 
 
 class ChatCompletionToolsParam(OpenAIBaseModel):
     type: Literal["function"] = "function"
     function: FunctionDefinition
+
+
+class ChatCompletionCustomToolParam(OpenAIBaseModel):
+    type: Literal["custom"]
+    custom: Dict[str, Any]
 
 
 class ChatCompletionNamedFunction(OpenAIBaseModel):
@@ -147,6 +175,16 @@ class ChatCompletionNamedFunction(OpenAIBaseModel):
 class ChatCompletionNamedToolChoiceParam(OpenAIBaseModel):
     function: ChatCompletionNamedFunction
     type: Literal["function"] = "function"
+
+
+class ChatCompletionAllowedTools(OpenAIBaseModel):
+    mode: Literal["auto", "required"]
+    tools: List[ChatCompletionNamedToolChoiceParam]
+
+
+class ChatCompletionAllowedToolChoiceParam(OpenAIBaseModel):
+    type: Literal["allowed_tools"]
+    allowed_tools: ChatCompletionAllowedTools
 
 
 # extra="forbid" is a workaround to have kwargs as a field,
@@ -166,8 +204,11 @@ class ChatCompletionRequest(OpenAIBaseModel):
     # Ordered by official OpenAI API documentation
     # https://platform.openai.com/docs/api-reference/chat/create
     messages: list[ChatCompletionMessageParam]
-    model: Optional[str] = None
+    model: str
+    audio: Optional[Dict[str, Any]] = None
     frequency_penalty: Optional[float] = 0.0
+    function_call: Optional[Union[Literal["none", "auto"], Dict[str, str]]] = None
+    functions: Optional[List[FunctionDefinition]] = None
     logit_bias: Optional[dict[str, float]] = None
     logprobs: Optional[bool] = False
     top_logprobs: Optional[int] = 0
@@ -177,28 +218,49 @@ class ChatCompletionRequest(OpenAIBaseModel):
     )
     max_completion_tokens: Optional[int] = None
     n: Optional[int] = 1
+    modalities: Optional[List[Literal["text", "audio"]]] = None
+    metadata: Optional[Dict[str, str]] = None
+    moderation: Optional[Dict[str, Any]] = None
     presence_penalty: Optional[float] = 0.0
+    prediction: Optional[Dict[str, Any]] = None
+    prompt_cache_key: Optional[str] = None
+    prompt_cache_options: Optional[Dict[str, Any]] = None
+    prompt_cache_retention: Optional[Literal["in_memory", "24h"]] = None
+    reasoning_effort: Optional[
+        Literal["none", "minimal", "low", "medium", "high", "xhigh"]
+    ] = None
     response_format: Optional[AnyResponseFormat] = None
+    safety_identifier: Optional[str] = None
     seed: Optional[int] = Field(None, ge=_LONG_INFO.min, le=_LONG_INFO.max)
+    service_tier: Optional[
+        Literal["auto", "default", "flex", "scale", "priority", "fast"]
+    ] = None
     stop: Optional[Union[str, list[str]]] = []
+    store: Optional[bool] = False
     stream: Optional[bool] = False
     stream_options: Optional[StreamOptions] = None
     temperature: Optional[float] = None
     top_p: Optional[float] = None
-    tools: Optional[list[ChatCompletionToolsParam]] = None
+    tools: Optional[
+        list[Union[ChatCompletionToolsParam, ChatCompletionCustomToolParam]]
+    ] = None
     tool_choice: Optional[
         Union[
             Literal["none"],
             Literal["auto"],
             Literal["required"],
             ChatCompletionNamedToolChoiceParam,
+            ChatCompletionAllowedToolChoiceParam,
+            Dict[str, Any],
         ]
-    ] = "none"
+    ] = None
 
     # Accepted for OpenAI schema compatibility; the model and tool parser
     # determine whether calls are emitted in parallel.
-    parallel_tool_calls: Optional[bool] = False
+    parallel_tool_calls: Optional[bool] = True
     user: Optional[str] = None
+    verbosity: Optional[Literal["low", "medium", "high"]] = None
+    web_search_options: Optional[Dict[str, Any]] = None
 
     # --8<-- [start:chat-completion-sampling-params]
     best_of: Optional[int] = None
@@ -384,6 +446,31 @@ class ChatCompletionRequest(OpenAIBaseModel):
 
     @model_validator(mode="before")
     @classmethod
+    def translate_legacy_functions(cls, values):
+        """Accept the deprecated functions/function_call wire format."""
+        if not isinstance(values, dict):
+            return values
+        if values.get("functions") is not None and values.get("tools") is None:
+            values = dict(values)
+            values["tools"] = [
+                {"type": "function", "function": function}
+                for function in values["functions"]
+            ]
+        if (
+            values.get("function_call") is not None
+            and values.get("tool_choice") is None
+        ):
+            values = dict(values)
+            function_call = values["function_call"]
+            values["tool_choice"] = (
+                function_call
+                if isinstance(function_call, str)
+                else {"type": "function", "function": function_call}
+            )
+        return values
+
+    @model_validator(mode="before")
+    @classmethod
     def check_guided_decoding_count(cls, data):
         guide_count = sum(
             [
@@ -399,7 +486,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 "('guided_json', 'guided_regex' or 'guided_choice')."
             )
         # you can only either use guided decoding or tools, not both
-        if guide_count > 1 and "tool_choice" in data and data["tool_choice"] != "none":
+        if guide_count > 0 and "tool_choice" in data and data["tool_choice"] != "none":
             raise ValueError(
                 "You can only either use guided decoding or tools, not both."
             )
@@ -408,11 +495,11 @@ class ChatCompletionRequest(OpenAIBaseModel):
     @model_validator(mode="before")
     @classmethod
     def check_tool_choice(cls, data):
-        if "tool_choice" in data and data["tool_choice"] != "none":
-            if not isinstance(data["tool_choice"], dict):
-                raise ValueError("Currently only named tools are supported.")
-            if "tools" not in data or data["tools"] is None:
-                raise ValueError("When using `tool_choice`, `tools` must be set.")
+        if not isinstance(data, dict):
+            return data
+        tool_choice = data.get("tool_choice")
+        if tool_choice not in (None, "none") and not data.get("tools"):
+            raise ValueError("When using `tool_choice`, `tools` must be set.")
         return data
 
     @model_validator(mode="before")
@@ -657,8 +744,12 @@ class ToolCall(OpenAIBaseModel):
 
 class ChatMessage(OpenAIBaseModel):
     role: str
-    content: str
-    tool_calls: List[ToolCall] = Field(default_factory=list)
+    content: Optional[str] = None
+    refusal: Optional[str] = None
+    annotations: Optional[List[Dict[str, Any]]] = None
+    audio: Optional[Dict[str, Any]] = None
+    function_call: Optional[FunctionCall] = None
+    tool_calls: Optional[List[ToolCall]] = None
 
 
 class ChatCompletionLogProb(OpenAIBaseModel):
@@ -691,6 +782,8 @@ class ChatCompletionResponse(OpenAIBaseModel):
     model: str
     choices: List[ChatCompletionResponseChoice]
     usage: UsageInfo
+    service_tier: Optional[str] = None
+    system_fingerprint: Optional[str] = "gllm"
 
 
 class DeltaFunctionCall(OpenAIBaseModel):
@@ -711,7 +804,8 @@ class DeltaToolCall(OpenAIBaseModel):
 class DeltaMessage(OpenAIBaseModel):
     role: Optional[str] = None
     content: Optional[str] = None
-    tool_calls: List[DeltaToolCall] = Field(default_factory=list)
+    refusal: Optional[str] = None
+    tool_calls: Optional[List[DeltaToolCall]] = None
 
 
 class ChatCompletionResponseStreamChoice(OpenAIBaseModel):
@@ -730,6 +824,48 @@ class ChatCompletionStreamResponse(OpenAIBaseModel):
     model: str
     choices: List[ChatCompletionResponseStreamChoice]
     usage: Optional[UsageInfo] = Field(default=None)
+    service_tier: Optional[str] = None
+    system_fingerprint: Optional[str] = "gllm"
+    obfuscation: Optional[str] = None
+
+
+class ResponseRequest(OpenAIBaseModel):
+    """Core current Responses API request supported by the local runtime.
+
+    Complex input and tool unions are validated semantically by the endpoint so
+    the wire schema can evolve without coupling the server to an SDK release.
+    """
+
+    model: str
+    input: Union[str, List[Any]]
+    instructions: Optional[Union[str, List[Any]]] = None
+    background: Optional[bool] = False
+    conversation: Optional[Union[str, Dict[str, Any]]] = None
+    include: Optional[List[str]] = None
+    max_output_tokens: Optional[int] = None
+    max_tool_calls: Optional[int] = None
+    metadata: Optional[Dict[str, str]] = None
+    moderation: Optional[Dict[str, Any]] = None
+    parallel_tool_calls: Optional[bool] = True
+    previous_response_id: Optional[str] = None
+    prompt: Optional[Dict[str, Any]] = None
+    prompt_cache_key: Optional[str] = None
+    prompt_cache_options: Optional[Dict[str, Any]] = None
+    prompt_cache_retention: Optional[Literal["in_memory", "24h"]] = None
+    reasoning: Optional[Dict[str, Any]] = None
+    safety_identifier: Optional[str] = None
+    service_tier: Optional[str] = None
+    store: Optional[bool] = False
+    stream: Optional[bool] = False
+    stream_options: Optional[Dict[str, Any]] = None
+    temperature: Optional[float] = None
+    text: Optional[Dict[str, Any]] = None
+    tool_choice: Optional[Union[str, Dict[str, Any]]] = None
+    tools: Optional[List[Dict[str, Any]]] = None
+    top_logprobs: Optional[int] = None
+    top_p: Optional[float] = None
+    truncation: Optional[Literal["auto", "disabled"]] = "disabled"
+    user: Optional[str] = None
 
 
 class BatchRequestInput(OpenAIBaseModel):

--- a/gllm/entrypoints/serving_chat.py
+++ b/gllm/entrypoints/serving_chat.py
@@ -1,3 +1,6 @@
+import secrets
+import time
+
 from gllm.engine.async_llm import AsyncStream
 from gllm.entrypoints.protocol import (
     ChatCompletionLogProb,
@@ -67,7 +70,7 @@ async def chat_completion_generator(
     # parser (unknown model) or tools, the raw text passes through as content.
     content = full_text
     tool_calls = []
-    if tool_parser is not None and request.tools:
+    if tool_parser is not None and request.tools and request.tool_choice != "none":
         parsed_content, tool_calls = tool_parser.parse(full_text, request.tools)
         content = parsed_content if parsed_content is not None else ""
 
@@ -80,15 +83,13 @@ async def chat_completion_generator(
     choice_data = ChatCompletionResponseChoice(
         index=0,
         message=ChatMessage(
-            role="assistant", content=content, tool_calls=tool_calls
+            role="assistant", content=content, tool_calls=tool_calls or None
         ),
         logprobs=logprobs,
         prompt_logprobs=prompt_logprobs,
         # OpenAI sets finish_reason="tool_calls" when the model chose to call a
         # tool; clients (and benchmarks) branch on this.
-        finish_reason=(
-            "tool_calls" if tool_calls else get_finish_reason(stream.seq)
-        ),
+        finish_reason=("tool_calls" if tool_calls else get_finish_reason(stream.seq)),
     )
     response = ChatCompletionResponse(
         choices=[choice_data],
@@ -108,9 +109,34 @@ async def chat_completion_stream_generator(
     # emits content fragments plus tool-call name/argument fragments tied by
     # ``index``. Otherwise stream raw text deltas.
     streaming = tool_parser is not None and bool(request.tools)
+    streaming = streaming and request.tool_choice != "none"
     sp = tool_parser.stream_parser(request.tools) if streaming else None
     full_text = ""
     as_token_ids = bool(request.return_tokens_as_token_ids)
+    response_id = f"chatcmpl-{request.request_id}"
+    created = int(time.time())
+    options = request.stream_options
+    include_usage = bool(options and options.include_usage)
+    continuous_usage = bool(options and options.continuous_usage_stats)
+    include_obfuscation = bool(options and options.include_obfuscation)
+
+    def make_chunk(choices, usage=None):
+        return ChatCompletionStreamResponse(
+            id=response_id,
+            created=created,
+            choices=choices,
+            model=request.model,
+            usage=usage,
+            service_tier=request.service_tier,
+            obfuscation=secrets.token_urlsafe(8) if include_obfuscation else None,
+        )
+
+    # The first OpenAI chat stream delta establishes the assistant role.
+    role_choice = ChatCompletionResponseStreamChoice(
+        index=0, delta=DeltaMessage(role="assistant")
+    )
+    role_chunk = make_chunk([role_choice])
+    yield f"data: {role_chunk.model_dump_json(exclude_none=True)}\n\n"
 
     async for item in stream:
         text = item.text
@@ -141,13 +167,16 @@ async def chat_completion_stream_generator(
                 logprobs=logprobs,
                 prompt_logprobs=prompt_logprobs,
             )
-        chunk = ChatCompletionStreamResponse(choices=[choice_data], model=request.model)
-        data = chunk.model_dump_json(exclude_unset=True)
+        chunk = make_chunk(
+            [choice_data],
+            build_usage(stream.seq) if continuous_usage else None,
+        )
+        data = chunk.model_dump_json(exclude_none=True)
         yield f"data: {data}\n\n"
 
     # Final chunk: empty delta carrying the finish_reason, mirroring the OpenAI
-    # streaming protocol. Usage is attached when the client opted in via
-    # ``stream_options.include_usage`` (default on in our schema).
+    # streaming protocol. OpenAI sends opted-in usage in a separate final
+    # chunk with an empty choices array.
     final_reason = get_finish_reason(stream.seq)
     if streaming and sp.has_tool_calls():
         final_reason = "tool_calls"
@@ -156,14 +185,9 @@ async def chat_completion_stream_generator(
         delta=DeltaMessage(),
         finish_reason=final_reason,
     )
-    include_usage = (
-        request.stream_options is None
-        or request.stream_options.include_usage
-    )
-    final_chunk = ChatCompletionStreamResponse(
-        choices=[final_choice],
-        model=request.model,
-        usage=build_usage(stream.seq) if include_usage else None,
-    )
-    yield f"data: {final_chunk.model_dump_json(exclude_unset=True)}\n\n"
+    final_chunk = make_chunk([final_choice])
+    yield f"data: {final_chunk.model_dump_json(exclude_none=True)}\n\n"
+    if include_usage:
+        usage_chunk = make_chunk([], build_usage(stream.seq))
+        yield f"data: {usage_chunk.model_dump_json(exclude_none=True)}\n\n"
     yield "data: [DONE]\n\n"

--- a/gllm/entrypoints/serving_completions.py
+++ b/gllm/entrypoints/serving_completions.py
@@ -1,3 +1,5 @@
+import time
+
 from gllm.engine.async_llm import AsyncStream
 from gllm.entrypoints.protocol import (
     CompletionLogProbs,
@@ -7,7 +9,7 @@ from gllm.entrypoints.protocol import (
     CompletionResponseStreamChoice,
     CompletionStreamResponse,
 )
-from gllm.utils import build_usage, get_finish_reason
+from gllm.utils import build_usage, get_finish_reason, random_uuid
 
 
 def _build_completion_logprobs(entries, text_offset_start=0):
@@ -56,6 +58,8 @@ async def completion_generator(stream: AsyncStream, request: CompletionRequest):
 
 async def completion_stream_generator(stream: AsyncStream, request: CompletionRequest):
     text_offset = 0
+    response_id = f"cmpl-{random_uuid()}"
+    created = int(time.time())
     async for item in stream:
         # Keep chunks that carry text OR a logprob (a multi-byte token can
         # produce an empty text delta whose logprob must still be reported) OR
@@ -72,23 +76,34 @@ async def completion_stream_generator(stream: AsyncStream, request: CompletionRe
             logprobs=logprobs,
             prompt_logprobs=item.prompt_logprobs,
         )
-        chunk = CompletionStreamResponse(choices=[choice_data], model=request.model)
-        data = chunk.model_dump_json(exclude_unset=False)
+        chunk = CompletionStreamResponse(
+            id=response_id,
+            created=created,
+            choices=[choice_data],
+            model=request.model,
+        )
+        data = chunk.model_dump_json(exclude_none=True)
         yield f"data: {data}\n\n"
 
     # Final chunk: empty text carrying the finish_reason; usage attached when
-    # the client opted in via ``stream_options.include_usage`` (default on).
+    # the client opted in via ``stream_options.include_usage``.
     final_choice = CompletionResponseStreamChoice(
         index=0, text="", finish_reason=get_finish_reason(stream.seq)
     )
-    include_usage = (
-        request.stream_options is None
-        or request.stream_options.include_usage
-    )
     final_chunk = CompletionStreamResponse(
+        id=response_id,
+        created=created,
         choices=[final_choice],
         model=request.model,
-        usage=build_usage(stream.seq) if include_usage else None,
     )
-    yield f"data: {final_chunk.model_dump_json(exclude_unset=False)}\n\n"
+    yield f"data: {final_chunk.model_dump_json(exclude_none=True)}\n\n"
+    if request.stream_options and request.stream_options.include_usage:
+        usage_chunk = CompletionStreamResponse(
+            id=response_id,
+            created=created,
+            choices=[],
+            model=request.model,
+            usage=build_usage(stream.seq),
+        )
+        yield f"data: {usage_chunk.model_dump_json(exclude_none=True)}\n\n"
     yield "data: [DONE]\n\n"

--- a/gllm/entrypoints/serving_responses.py
+++ b/gllm/entrypoints/serving_responses.py
@@ -1,0 +1,673 @@
+import base64
+import binascii
+import io
+import json
+import mimetypes
+import time
+from pathlib import PurePosixPath
+from typing import Any, Dict, List, Tuple
+from urllib.parse import unquote, unquote_to_bytes, urlparse
+from urllib.request import Request, urlopen
+
+from PIL import Image
+
+from gllm.engine.async_llm import AsyncStream
+from gllm.entrypoints.protocol import ChatCompletionRequest, ResponseRequest
+from gllm.entrypoints.serving_chat import chat_completion_generator
+from gllm.tokenizers.tool_parsers import ToolParser
+from gllm.utils import build_usage, get_finish_reason, random_uuid
+
+_MAX_INLINE_FILE_BYTES = 50 * 1024 * 1024
+_TEXT_EXTENSIONS = {
+    ".c",
+    ".cc",
+    ".cpp",
+    ".css",
+    ".csv",
+    ".go",
+    ".h",
+    ".hpp",
+    ".html",
+    ".ini",
+    ".java",
+    ".js",
+    ".json",
+    ".jsx",
+    ".log",
+    ".md",
+    ".py",
+    ".rb",
+    ".rs",
+    ".sh",
+    ".sql",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".xml",
+    ".yaml",
+    ".yml",
+}
+
+
+def _data_url_bytes(value: str, param: str) -> Tuple[bytes, str | None]:
+    """Decode an OpenAI ``file_data`` value (data URL or raw base64)."""
+    mime_type = None
+    payload = value
+    if value.startswith("data:"):
+        try:
+            header, payload = value.split(",", 1)
+        except ValueError as exc:
+            raise ValueError(param, "Invalid data URL in `file_data`.") from exc
+        metadata = header[5:].split(";")
+        mime_type = metadata[0] or None
+        if "base64" not in metadata[1:]:
+            return unquote_to_bytes(payload), mime_type
+    try:
+        return base64.b64decode(payload, validate=True), mime_type
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError(param, "`file_data` must be Base64 or a data URL.") from exc
+
+
+def _download_file(url: str, param: str) -> Tuple[bytes, str | None, str | None]:
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(param, "`file_url` must use http or https.")
+    request = Request(url, headers={"User-Agent": "gLLM/Responses"})
+    try:
+        with urlopen(request, timeout=30) as response:
+            content_length = response.headers.get("Content-Length")
+            if content_length and int(content_length) > _MAX_INLINE_FILE_BYTES:
+                raise ValueError(param, "Input files are limited to 50 MB.")
+            data = response.read(_MAX_INLINE_FILE_BYTES + 1)
+            mime_type = response.headers.get_content_type()
+            disposition = response.headers.get_filename()
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise ValueError(param, f"Unable to download `file_url`: {exc}") from exc
+    if len(data) > _MAX_INLINE_FILE_BYTES:
+        raise ValueError(param, "Input files are limited to 50 MB.")
+    url_name = PurePosixPath(unquote(parsed.path)).name or None
+    return data, mime_type, disposition or url_name
+
+
+def _decode_text_file(data: bytes, param: str) -> str:
+    encodings = (
+        ("utf-16", "utf-8-sig")
+        if data.startswith((b"\xff\xfe", b"\xfe\xff"))
+        else ("utf-8-sig",)
+    )
+    for encoding in encodings:
+        try:
+            return data.decode(encoding)
+        except UnicodeDecodeError:
+            pass
+    if b"\x00" in data[:4096]:
+        raise ValueError(param, "This binary document type is not supported yet.")
+    return data.decode("latin-1")
+
+
+def _input_file_parts(part: Dict[str, Any], param: str) -> List[Dict[str, Any]]:
+    sources = [key for key in ("file_data", "file_url", "file_id") if part.get(key)]
+    if len(sources) != 1:
+        raise ValueError(
+            param,
+            "`input_file` requires exactly one of `file_data`, `file_url`, or `file_id`.",
+        )
+    source = sources[0]
+    if source == "file_id":
+        raise ValueError(
+            f"{param}.file_id",
+            "File IDs require the Files API, which this server does not implement yet; use `file_data` or `file_url`.",
+        )
+
+    filename = part.get("filename")
+    if source == "file_data":
+        data, mime_type = _data_url_bytes(part[source], f"{param}.file_data")
+    else:
+        data, mime_type, downloaded_name = _download_file(
+            part[source], f"{param}.file_url"
+        )
+        filename = filename or downloaded_name
+    if len(data) > _MAX_INLINE_FILE_BYTES:
+        raise ValueError(param, "Input files are limited to 50 MB.")
+
+    filename = filename or "input_file"
+    extension = PurePosixPath(filename).suffix.lower()
+    guessed_type = mimetypes.guess_type(filename)[0]
+    mime_type = mime_type or guessed_type or "application/octet-stream"
+    if mime_type == "application/octet-stream" and data.startswith(b"%PDF-"):
+        mime_type = "application/pdf"
+
+    if mime_type.startswith("image/"):
+        try:
+            image = Image.open(io.BytesIO(data)).convert("RGB")
+        except Exception as exc:
+            raise ValueError(param, f"Unable to decode image file: {exc}") from exc
+        return [{"type": "image", "image": image}]
+    if mime_type == "application/pdf" or extension == ".pdf":
+        raise ValueError(
+            param,
+            "PDF file inputs are not supported by this server.",
+        )
+    if mime_type.startswith("text/") or extension in _TEXT_EXTENSIONS:
+        text = _decode_text_file(data, param)
+        return [{"type": "text", "text": f"\n[File: {filename}]\n{text}\n"}]
+    raise ValueError(
+        param,
+        f"Unsupported input file type {mime_type!r}; use an image or a text/code/CSV file.",
+    )
+
+
+def _response_content_parts(
+    content: List[Any], param: str
+) -> Tuple[List[Dict[str, Any]], bool]:
+    parts: List[Dict[str, Any]] = []
+    has_media = False
+    for part_index, part in enumerate(content):
+        part_param = f"{param}.{part_index}"
+        if not isinstance(part, dict):
+            raise ValueError(part_param, "Content parts must be objects.")
+        part_type = part.get("type")
+        if part_type in ("input_text", "output_text", "text"):
+            parts.append({"type": "text", "text": part.get("text", "")})
+        elif part_type == "input_image":
+            image_url = part.get("image_url")
+            file_id = part.get("file_id")
+            if bool(image_url) == bool(file_id):
+                raise ValueError(
+                    part_param,
+                    "`input_image` requires exactly one of `image_url` or `file_id`.",
+                )
+            if file_id:
+                raise ValueError(
+                    f"{part_param}.file_id",
+                    "Image file IDs require the Files API; use `image_url` with a URL or data URL.",
+                )
+            # This is the gLLM-native media shape. Do not route Responses input
+            # through the Chat Completions ``image_url`` wire representation.
+            parts.append({"type": "image", "image": image_url})
+            has_media = True
+        elif part_type == "input_file":
+            file_parts = _input_file_parts(part, part_param)
+            parts.extend(file_parts)
+            has_media = has_media or any(p["type"] == "image" for p in file_parts)
+        elif part_type == "input_audio":
+            raise ValueError(part_param, "Audio input is not supported yet.")
+        else:
+            raise ValueError(
+                part_param, f"Unsupported Responses content type: {part_type!r}."
+            )
+    return parts, has_media
+
+
+def response_input_to_messages(request: ResponseRequest) -> List[Dict[str, Any]]:
+    """Parse Responses input into the gLLM-native chat/media representation."""
+    messages: List[Dict[str, Any]] = []
+    if request.instructions:
+        if not isinstance(request.instructions, str):
+            raise ValueError("instructions", "Only string instructions are supported.")
+        messages.append({"role": "developer", "content": request.instructions})
+
+    if isinstance(request.input, str):
+        messages.append({"role": "user", "content": request.input})
+        return messages
+
+    for index, item in enumerate(request.input):
+        param = f"input.{index}"
+        if isinstance(item, str):
+            messages.append({"role": "user", "content": item})
+            continue
+        if not isinstance(item, dict):
+            raise ValueError(param, "Input items must be strings or objects.")
+        item_type = item.get("type")
+        if item_type == "function_call":
+            call_id = item.get("call_id") or item.get("id")
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {
+                                "name": item.get("name"),
+                                "arguments": item.get("arguments", "{}"),
+                            },
+                        }
+                    ],
+                }
+            )
+            continue
+        if item_type == "function_call_output":
+            output = item.get("output", "")
+            if not isinstance(output, str):
+                output = json.dumps(output, ensure_ascii=False)
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": item.get("call_id"),
+                    "content": output,
+                }
+            )
+            continue
+        if item_type not in (None, "message") or "role" not in item:
+            raise ValueError(param, f"Unsupported Responses input type: {item_type!r}.")
+        content = item.get("content", "")
+        if isinstance(content, list):
+            parts, has_media = _response_content_parts(content, f"{param}.content")
+            content = parts if has_media else "".join(part["text"] for part in parts)
+        elif not isinstance(content, str):
+            raise ValueError(f"{param}.content", "Message content must be text.")
+        messages.append({"role": item["role"], "content": content})
+    if not any(message.get("role") == "user" for message in messages):
+        raise ValueError(
+            "input",
+            "Stateless Responses requests must include a user message; previous_response_id is not supported.",
+        )
+    return messages
+
+
+def response_tools_to_chat(tools):
+    if not tools:
+        return None
+    translated = []
+    for index, tool in enumerate(tools):
+        if tool.get("type") != "function":
+            raise ValueError(
+                f"tools.{index}", "Only function tools are supported by this runtime."
+            )
+        translated.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": tool.get("name"),
+                    "description": tool.get("description"),
+                    "parameters": tool.get("parameters"),
+                    "strict": tool.get("strict"),
+                },
+            }
+        )
+    return translated
+
+
+def make_chat_request(request: ResponseRequest) -> ChatCompletionRequest:
+    effort = (request.reasoning or {}).get("effort")
+    return ChatCompletionRequest.model_validate(
+        {
+            "model": request.model,
+            "messages": response_input_to_messages(request),
+            "max_completion_tokens": request.max_output_tokens,
+            "temperature": request.temperature,
+            "top_p": request.top_p,
+            "tools": response_tools_to_chat(request.tools),
+            "tool_choice": request.tool_choice,
+            "parallel_tool_calls": request.parallel_tool_calls,
+            "reasoning_effort": effort,
+            "request_id": random_uuid(),
+        }
+    )
+
+
+def _usage(chat_response):
+    usage = chat_response.usage
+    return {
+        "input_tokens": usage.prompt_tokens,
+        "input_tokens_details": {"cached_tokens": 0, "cache_write_tokens": 0},
+        "output_tokens": usage.completion_tokens or 0,
+        "output_tokens_details": {"reasoning_tokens": 0},
+        "total_tokens": usage.total_tokens,
+    }
+
+
+def _base_response(request: ResponseRequest, *, response_id: str, created_at: int):
+    effort = (request.reasoning or {}).get("effort")
+    return {
+        "id": response_id,
+        "object": "response",
+        "created_at": created_at,
+        "status": "in_progress",
+        "background": False,
+        "completed_at": None,
+        "error": None,
+        "incomplete_details": None,
+        "instructions": request.instructions,
+        "max_output_tokens": request.max_output_tokens,
+        "max_tool_calls": request.max_tool_calls,
+        "model": request.model,
+        "output": [],
+        "parallel_tool_calls": bool(request.parallel_tool_calls),
+        "previous_response_id": request.previous_response_id,
+        "reasoning": {"effort": effort, "summary": None},
+        "store": False,
+        "temperature": request.temperature,
+        "text": request.text or {"format": {"type": "text"}},
+        "tool_choice": request.tool_choice or ("auto" if request.tools else "none"),
+        "tools": request.tools or [],
+        "top_p": request.top_p,
+        "truncation": request.truncation or "disabled",
+        "usage": None,
+        "user": request.user,
+        "metadata": request.metadata or {},
+        "service_tier": request.service_tier,
+    }
+
+
+async def response_completion_generator(
+    stream: AsyncStream,
+    request: ResponseRequest,
+    chat_request: ChatCompletionRequest,
+    tool_parser: ToolParser = None,
+):
+    chat_response = await chat_completion_generator(stream, chat_request, tool_parser)
+    response_id = f"resp_{random_uuid()}"
+    created_at = int(time.time())
+    response = _base_response(request, response_id=response_id, created_at=created_at)
+    choice = chat_response.choices[0]
+    output = []
+    if choice.message.tool_calls:
+        for tool_call in choice.message.tool_calls:
+            output.append(
+                {
+                    "id": f"fc_{random_uuid()}",
+                    "call_id": tool_call.id,
+                    "type": "function_call",
+                    "name": tool_call.function.name,
+                    "arguments": tool_call.function.arguments,
+                    "status": "completed",
+                }
+            )
+    else:
+        output.append(
+            {
+                "id": f"msg_{random_uuid()}",
+                "type": "message",
+                "status": "completed",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "annotations": [],
+                        "logprobs": [],
+                        "text": choice.message.content or "",
+                    }
+                ],
+            }
+        )
+    incomplete = choice.finish_reason == "length"
+    response.update(
+        {
+            "status": "incomplete" if incomplete else "completed",
+            "completed_at": int(time.time()),
+            "incomplete_details": (
+                {"reason": "max_output_tokens"} if incomplete else None
+            ),
+            "output": output,
+            "usage": _usage(chat_response),
+        }
+    )
+    return response
+
+
+def _sse(event: Dict[str, Any]):
+    return f"event: {event['type']}\ndata: {json.dumps(event, ensure_ascii=False)}\n\n"
+
+
+async def response_stream_generator(
+    stream: AsyncStream,
+    request: ResponseRequest,
+    chat_request: ChatCompletionRequest,
+    tool_parser: ToolParser = None,
+):
+    """Translate engine deltas directly into Responses API SSE events."""
+    sequence = 0
+
+    def event(event_type, **payload):
+        nonlocal sequence
+        value = {"type": event_type, "sequence_number": sequence, **payload}
+        sequence += 1
+        return value
+
+    response_id = f"resp_{random_uuid()}"
+    created_at = int(time.time())
+    initial = _base_response(request, response_id=response_id, created_at=created_at)
+    yield _sse(event("response.created", response=initial))
+    yield _sse(event("response.in_progress", response=initial))
+
+    parse_tools = (
+        tool_parser is not None
+        and bool(chat_request.tools)
+        and chat_request.tool_choice != "none"
+    )
+    stream_parser = (
+        tool_parser.stream_parser(chat_request.tools) if parse_tools else None
+    )
+    full_text = ""
+    message_text = ""
+    message_id = None
+    message_index = None
+    message_done = False
+    outputs = []
+    next_output_index = 0
+
+    def start_message_events():
+        nonlocal message_id, message_index, next_output_index
+        if message_id is not None:
+            return []
+        message_id = f"msg_{random_uuid()}"
+        message_index = next_output_index
+        next_output_index += 1
+        added = {
+            "id": message_id,
+            "type": "message",
+            "status": "in_progress",
+            "role": "assistant",
+            "content": [],
+        }
+        empty_part = {
+            "type": "output_text",
+            "annotations": [],
+            "logprobs": [],
+            "text": "",
+        }
+        return [
+            _sse(
+                event(
+                    "response.output_item.added",
+                    output_index=message_index,
+                    item=added,
+                )
+            ),
+            _sse(
+                event(
+                    "response.content_part.added",
+                    output_index=message_index,
+                    item_id=message_id,
+                    content_index=0,
+                    part=empty_part,
+                )
+            ),
+        ]
+
+    def finish_message_events():
+        nonlocal message_done
+        if message_id is None or message_done:
+            return []
+        message_done = True
+        part = {
+            "type": "output_text",
+            "annotations": [],
+            "logprobs": [],
+            "text": message_text,
+        }
+        item = {
+            "id": message_id,
+            "type": "message",
+            "status": "completed",
+            "role": "assistant",
+            "content": [part],
+        }
+        outputs.append(item)
+        return [
+            _sse(
+                event(
+                    "response.output_text.done",
+                    output_index=message_index,
+                    item_id=message_id,
+                    content_index=0,
+                    text=message_text,
+                    logprobs=[],
+                )
+            ),
+            _sse(
+                event(
+                    "response.content_part.done",
+                    output_index=message_index,
+                    item_id=message_id,
+                    content_index=0,
+                    part=part,
+                )
+            ),
+            _sse(
+                event(
+                    "response.output_item.done",
+                    output_index=message_index,
+                    item=item,
+                )
+            ),
+        ]
+
+    # Without model-native tool markup the output is known to be a message, so
+    # announce its item/part before waiting for the first generated token.
+    if stream_parser is None:
+        for wire_event in start_message_events():
+            yield wire_event
+
+    async for stream_item in stream:
+        text = stream_item.text
+        if not text:
+            continue
+        full_text += text
+        if stream_parser is None:
+            deltas = [text]
+            tool_deltas = []
+        else:
+            parsed_deltas = []
+            # One engine delta may finish both a text prefix and one or more
+            # tool-call blocks. Drain every newly available parser delta.
+            while True:
+                parsed = stream_parser.process(full_text)
+                if parsed is None:
+                    break
+                parsed_deltas.append(parsed)
+            deltas = [delta.content for delta in parsed_deltas if delta.content]
+            tool_deltas = [
+                tool_call
+                for delta in parsed_deltas
+                for tool_call in (delta.tool_calls or [])
+            ]
+
+        for text_delta in deltas:
+            for wire_event in start_message_events():
+                yield wire_event
+            message_text += text_delta
+            yield _sse(
+                event(
+                    "response.output_text.delta",
+                    output_index=message_index,
+                    item_id=message_id,
+                    content_index=0,
+                    delta=text_delta,
+                    logprobs=[],
+                )
+            )
+
+        for tool_call in tool_deltas:
+            # Natural-language content, when present, precedes tool-call output
+            # items and must be finalized before the next item is announced.
+            for wire_event in finish_message_events():
+                yield wire_event
+            function = tool_call.function
+            if function is None or function.name is None:
+                continue
+            arguments = function.arguments or ""
+            output_index = next_output_index
+            next_output_index += 1
+            item = {
+                "id": f"fc_{random_uuid()}",
+                "call_id": tool_call.id or f"call_{random_uuid()}",
+                "type": "function_call",
+                "name": function.name,
+                "arguments": arguments,
+                "status": "completed",
+            }
+            added = {**item, "status": "in_progress", "arguments": ""}
+            yield _sse(
+                event(
+                    "response.output_item.added",
+                    output_index=output_index,
+                    item=added,
+                )
+            )
+            if arguments:
+                yield _sse(
+                    event(
+                        "response.function_call_arguments.delta",
+                        output_index=output_index,
+                        item_id=item["id"],
+                        delta=arguments,
+                    )
+                )
+            yield _sse(
+                event(
+                    "response.function_call_arguments.done",
+                    output_index=output_index,
+                    item_id=item["id"],
+                    name=item["name"],
+                    arguments=arguments,
+                )
+            )
+            yield _sse(
+                event(
+                    "response.output_item.done",
+                    output_index=output_index,
+                    item=item,
+                )
+            )
+            outputs.append(item)
+
+    # Empty generations still produce a valid empty assistant message.
+    if not outputs and message_id is None:
+        for wire_event in start_message_events():
+            yield wire_event
+    for wire_event in finish_message_events():
+        yield wire_event
+
+    finish_reason = get_finish_reason(stream.seq)
+    incomplete = finish_reason == "length"
+    usage = build_usage(stream.seq)
+    final = dict(initial)
+    final.update(
+        {
+            "status": "incomplete" if incomplete else "completed",
+            "completed_at": int(time.time()),
+            "incomplete_details": (
+                {"reason": "max_output_tokens"} if incomplete else None
+            ),
+            "output": outputs,
+            "usage": {
+                "input_tokens": usage.prompt_tokens,
+                "input_tokens_details": {
+                    "cached_tokens": 0,
+                    "cache_write_tokens": 0,
+                },
+                "output_tokens": usage.completion_tokens or 0,
+                "output_tokens_details": {"reasoning_tokens": 0},
+                "total_tokens": usage.total_tokens,
+            },
+        }
+    )
+    terminal_event = "response.incomplete" if incomplete else "response.completed"
+    yield _sse(event(terminal_event, response=final))

--- a/gllm/runtime/model_runner.py
+++ b/gllm/runtime/model_runner.py
@@ -1,5 +1,5 @@
-import hashlib
 import gc
+import hashlib
 import os
 from collections import OrderedDict
 from contextlib import nullcontext as _nullcontext
@@ -17,10 +17,9 @@ from transformers import (
     PreTrainedTokenizerFast,
 )
 from transformers.image_utils import load_images
-from transformers.video_utils import load_video
 from transformers.tokenization_utils_base import VERY_LARGE_INTEGER
+from transformers.video_utils import load_video
 
-from gllm.runtime.async_runtime import FutureMap, OverlapRuntime
 from gllm.distributed.parallel_state import (
     get_dp_size,
     get_ipc_tp_group,
@@ -36,8 +35,6 @@ from gllm.distributed.parallel_state import (
     is_output_rank,
     set_dp_forward_counts,
 )
-from gllm.runtime.forward_metadata import ForwardMetadataPlan
-from gllm.runtime.input_data import InputData
 from gllm.layers.attention.qkv_backends import (
     bind_qkv_attention_backend,
     create_qkv_attention_backend,
@@ -45,12 +42,16 @@ from gllm.layers.attention.qkv_backends import (
 )
 from gllm.layers.rotary_embedding import MRotaryEmbedding
 from gllm.layers.sampler import Sampler
+from gllm.runtime.async_runtime import FutureMap, OverlapRuntime
+from gllm.runtime.forward_metadata import ForwardMetadataPlan
+from gllm.runtime.input_data import InputData
 from gllm.runtime.memory_manager import MemoryManager, PrefixMemoryManager
 from gllm.runtime.model_loader import ModelLoader, propagate_serving_config
-from gllm.speculative.async_state import MtpAsyncBatchState, MtpAsyncCompletion
-from gllm.speculative.gpu_prep import MtpGpuPrep
 from gllm.runtime.piecewise_cuda_graph import PiecewiseGraphRunner
 from gllm.runtime.sequence import GenerationSequence
+from gllm.speculative.async_state import MtpAsyncBatchState, MtpAsyncCompletion
+from gllm.speculative.gpu_prep import MtpGpuPrep
+from gllm.tokenizers.tool_parsers import normalize_chat_template_messages
 from gllm.utils import unify_decode
 
 
@@ -114,15 +115,15 @@ class DisaggSeqState:
     """
 
     num_items: int
-    item_span: List[Tuple[int, int]]          # ordered: (start, end) in tokens
+    item_span: List[Tuple[int, int]]  # ordered: (start, end) in tokens
     item_modality: List[str]
     item_ready: List[bool]
     item_embed: List[Optional[torch.Tensor]]  # ordered, filled on NIXL notif
     image_grid_thw: Optional[torch.Tensor]
     video_grid_thw: Optional[torch.Tensor]
-    input_ids_cpu: torch.Tensor               # full expanded prompt ids (cpu)
-    is_multimodal_cpu: torch.Tensor           # full mask (cpu)
-    prompt_positions: torch.Tensor            # full-prompt mrope positions
+    input_ids_cpu: torch.Tensor  # full expanded prompt ids (cpu)
+    is_multimodal_cpu: torch.Tensor  # full mask (cpu)
+    prompt_positions: torch.Tensor  # full-prompt mrope positions
     mrope_position_delta: torch.Tensor
     prompt_len: int
 
@@ -289,15 +290,13 @@ class ModelRunner:
     ):
 
         self.max_num_batched_tokens = (
-            maxp
-            if schedule_method in ["chunked_prefill", "split_pd"]
-            else maxp + maxd
+            maxp if schedule_method in ["chunked_prefill", "split_pd"] else maxp + maxd
         )
-        
+
         # Concurrent decode slots (SSM arena entries, input buffers, CUDA
         # graph capture). Bounded by ``maxd`` for all schedule methods.
         self.max_running_seqs = maxd
-        
+
         self.model_path = model_path
         self.model_loader = ModelLoader(
             load_format,
@@ -310,9 +309,7 @@ class ModelRunner:
         self.gpu_memory_util = gpu_memory_util
         self.page_size = page_size
         self._piecewise_cuda_graph_cfg = piecewise_cuda_graph
-        self._max_piecewise_cuda_graph_tokens_cfg = (
-            max_piecewise_cuda_graph_tokens
-        )
+        self._max_piecewise_cuda_graph_tokens_cfg = max_piecewise_cuda_graph_tokens
         # Recurrent-state (GDN/Mamba) prefix-cache granularity, in tokens.
         # Only meaningful for hybrid models with prefix caching on.
         self.ssm_snapshot_stride_tokens = ssm_snapshot_stride_tokens
@@ -327,8 +324,7 @@ class ModelRunner:
         # runner is pickled to spawn TP workers); the encoder itself is
         # lazy-loaded per process inside ``encode`` via a module-level cache.
         self._use_dsv32_encoder = (
-            getattr(self.model_loader, "architecture", None)
-            == "DeepseekV32ForCausalLM"
+            getattr(self.model_loader, "architecture", None) == "DeepseekV32ForCausalLM"
         )
         self.maxp = maxp
         self.maxd = maxd
@@ -396,9 +392,7 @@ class ModelRunner:
         # when present (Qwen3.5 requires float32), otherwise it falls back to
         # the activation dtype. Explicit CLI values override that recommendation.
         self.mamba_ssm_cache_dtype = (mamba_ssm_cache_dtype or "auto").lower()
-        if self.mamba_ssm_cache_dtype not in (
-            "auto", "bfloat16", "float16", "float32"
-        ):
+        if self.mamba_ssm_cache_dtype not in ("auto", "bfloat16", "float16", "float32"):
             raise ValueError(
                 "mamba_ssm_cache_dtype must be 'auto', 'bfloat16', 'float16' or "
                 f"'float32', got {self.mamba_ssm_cache_dtype!r}."
@@ -469,7 +463,6 @@ class ModelRunner:
                 self.image_processor.size["longest_edge"] = mm_processor_max_pixels
                 self.video_processor.size["longest_edge"] = mm_processor_max_pixels
                 logger.info(f"Max pixels: {mm_processor_max_pixels}")
-            
 
         # lazy init
         self.model: torch.nn.Module = None
@@ -495,9 +488,7 @@ class ModelRunner:
         # seq_id) so it survives across requests. Disabled cheaply when the
         # model isn't multimodal: the put/get paths are guarded by
         # ``self.use_mm`` callers.
-        self.mm_embed_cache = MultiModalEmbeddingCache(
-            max_entries=64, max_mb=256.0
-        )
+        self.mm_embed_cache = MultiModalEmbeddingCache(max_entries=64, max_mb=256.0)
 
         # cuda graph
         self.disable_cuda_graph = disable_cuda_graph
@@ -660,9 +651,7 @@ class ModelRunner:
                     )
                 else:
                     try:
-                        from flash_attn.cute import (  # noqa: F401
-                            flash_attn_varlen_func,
-                        )
+                        from flash_attn.cute import flash_attn_varlen_func  # noqa: F401
                     except Exception as exc:
                         mla_error = str(exc)
                 if mla_error is not None:
@@ -736,8 +725,7 @@ class ModelRunner:
         # MTP speculative decoding: number of draft tokens per step (k). Active
         # only when the model built an MTP head (mtp_enabled + nextn layers).
         self._mtp_k = (
-            self._mtp_k_cfg
-            if getattr(self.model, "mtp", None) is not None else 0
+            self._mtp_k_cfg if getattr(self.model, "mtp", None) is not None else 0
         )
         # The one authoritative runtime capability flag. The earlier resolved
         # preference only controls whether the loader constructs the MTP head;
@@ -907,8 +895,7 @@ class ModelRunner:
             and is_last_pp_rank()
         )
         self._piecewise_generic_on = (
-            self._piecewise_cuda_graph_on
-            and self._piecewise_cuda_graph_cfg is True
+            self._piecewise_cuda_graph_on and self._piecewise_cuda_graph_cfg is True
         )
         if piecewise_requested and not piecewise_model_supported:
             logger.warning(
@@ -917,26 +904,20 @@ class ModelRunner:
                 "forwards.",
                 type(self.model).__name__,
             )
-        from gllm.layers.ops.fla._sgl_compat import (
-            set_piecewise_cuda_graph_enabled,
-        )
+        from gllm.layers.ops.fla._sgl_compat import set_piecewise_cuda_graph_enabled
 
         set_piecewise_cuda_graph_enabled(self._piecewise_cuda_graph_on)
         self._piecewise_runner = None
         if self._piecewise_cuda_graph_on:
             piecewise_capture_limit = self.max_num_batched_tokens
             if self._max_piecewise_cuda_graph_tokens_cfg is not None:
-                configured_limit = int(
-                    self._max_piecewise_cuda_graph_tokens_cfg
-                )
+                configured_limit = int(self._max_piecewise_cuda_graph_tokens_cfg)
                 if configured_limit <= 0:
                     raise ValueError(
                         "max_piecewise_cuda_graph_tokens must be positive, got "
                         f"{configured_limit}"
                     )
-                piecewise_capture_limit = min(
-                    piecewise_capture_limit, configured_limit
-                )
+                piecewise_capture_limit = min(piecewise_capture_limit, configured_limit)
             piecewise_capture_sizes = PiecewiseGraphRunner.build_capture_sizes(
                 piecewise_capture_limit
             )
@@ -948,11 +929,7 @@ class ModelRunner:
                 "Piecewise CUDA graph enabled (mode=%s, max_tokens=%d; "
                 "attention/GDN eager breaks, graph-resident MoE, "
                 "bucket_sizes=%s)",
-                (
-                    "auto-mtp"
-                    if self._piecewise_cuda_graph_cfg is None
-                    else "generic"
-                ),
+                ("auto-mtp" if self._piecewise_cuda_graph_cfg is None else "generic"),
                 piecewise_capture_limit,
                 piecewise_capture_sizes,
             )
@@ -990,8 +967,7 @@ class ModelRunner:
         # ``GLLM_MTP_GPUPREP=0`` falls back to the CPU builders (``cal_input``).
         self._mtp_gpu_prep = None
         self._mtp_gpu_prep_on = (
-            self.mtp_enabled
-            and os.environ.get("GLLM_MTP_GPUPREP", "1") == "1"
+            self.mtp_enabled and os.environ.get("GLLM_MTP_GPUPREP", "1") == "1"
         )
         # Persistent pinned/device staging for the per-seq sampling params (see
         # ``_mtp_sample_params``); lazily allocated on first use.
@@ -1003,11 +979,7 @@ class ModelRunner:
             self._mtp_gpu_prep = MtpGpuPrep(
                 max_bs=max(self.max_running_seqs, 1),
                 max_blocks=self.input_data.max_num_block,
-                bt_width=(
-                    1 + self._mtp_k
-                    if self.memory_manager.use_ssm_cache
-                    else 0
-                ),
+                bt_width=(1 + self._mtp_k if self.memory_manager.use_ssm_cache else 0),
                 page_size=self.page_size,
                 uses_mrope=self.uses_mrope,
                 device=torch.device("cuda", torch.cuda.current_device()),
@@ -1046,9 +1018,7 @@ class ModelRunner:
         self._mtp_mixed_new_idx_host = torch.empty(
             mixed_cap, dtype=torch.int64, device="cpu", pin_memory=True
         )
-        self._mtp_mixed_new_ctx_host = torch.empty_like(
-            self._mtp_mixed_new_idx_host
-        )
+        self._mtp_mixed_new_ctx_host = torch.empty_like(self._mtp_mixed_new_idx_host)
         self._mtp_mixed_new_idx_host_np = self._mtp_mixed_new_idx_host.numpy()
         self._mtp_mixed_new_ctx_host_np = self._mtp_mixed_new_ctx_host.numpy()
         self._mtp_mixed_new_idx = torch.empty(
@@ -1110,6 +1080,7 @@ class ModelRunner:
         if tools:
             template_kwargs["tools"] = tools
         if chat:
+            normalize_chat_template_messages(messages)
             # OpenAI-style requests may send ``content: null`` (e.g. an assistant
             # turn that only carries ``tool_calls``). Many chat templates assume
             # ``content`` is a str or list and iterate it in the non-string
@@ -1126,9 +1097,7 @@ class ModelRunner:
             if dsv32_encoder is not None and (not self.use_mm or not has_mm):
                 # DeepSeek-V3.2: render with the model's official encoder
                 # (reference DSML format) instead of a Jinja chat template.
-                from gllm.tokenizers.deepseek_v32 import (
-                    apply_dsv32_chat_template,
-                )
+                from gllm.tokenizers.deepseek_v32 import apply_dsv32_chat_template
 
                 out = apply_dsv32_chat_template(
                     dsv32_encoder,
@@ -1221,7 +1190,11 @@ class ModelRunner:
                         data = data["url"]
                     content["video"] = data
                     mm_contents["video"].append(data)
-        return mm_contents if len(mm_contents["image"]) + len(mm_contents["video"]) != 0 else None
+        return (
+            mm_contents
+            if len(mm_contents["image"]) + len(mm_contents["video"]) != 0
+            else None
+        )
 
     def extract_mm_items_ordered(self, messages: List[Dict]):
         """Return the mm items as an ordered ``[(modality, content), ...]`` list.
@@ -1319,9 +1292,7 @@ class ModelRunner:
                     # and a text-only prompt may never have created an entry --
                     # touching it would raise ``KeyError`` and crash the engine.
                     batch_positions.append(
-                        torch.arange(
-                            seq.computed_token_num, seq.seq_len, device="cpu"
-                        )
+                        torch.arange(seq.computed_token_num, seq.seq_len, device="cpu")
                     )
                 num_decode_tokens += seq.to_compute_token_num
                 continue
@@ -1366,16 +1337,14 @@ class ModelRunner:
                     seq._mm_precomputed = None
                 else:
                     mm_embeddings = None
-                    mm_input, image_grid_thw, video_grid_thw = (
-                        self._mm_run_processor(seq)
+                    mm_input, image_grid_thw, video_grid_thw = self._mm_run_processor(
+                        seq
                     )
-                    input_ids_cpu, is_multimodal_cpu = (
-                        self._mm_build_is_multimodal_cpu(seq)
+                    input_ids_cpu, is_multimodal_cpu = self._mm_build_is_multimodal_cpu(
+                        seq
                     )
-                    mm_bundle_key, item_hashes = (
-                        self._build_mm_content_hashes(
-                            mm_input, image_grid_thw, video_grid_thw
-                        )
+                    mm_bundle_key, item_hashes = self._build_mm_content_hashes(
+                        mm_input, image_grid_thw, video_grid_thw
                     )
                     if item_hashes:
                         seq.hash_token_ids = self._splice_mm_pad_ids(
@@ -1403,9 +1372,7 @@ class ModelRunner:
                     # Kimi: plain 1-D positions over the full prompt. Stored in
                     # EmbeddingInfo so decode can extrapolate; ``mrope_position
                     # _delta`` is unused (decode uses ``torch.arange``).
-                    prompt_positions = torch.arange(
-                        len(seq.token_ids), device="cpu"
-                    )
+                    prompt_positions = torch.arange(len(seq.token_ids), device="cpu")
                     mrope_position_delta = None
                     batch_positions.append(
                         prompt_positions[seq.computed_token_num : seq.seq_len]
@@ -1500,9 +1467,7 @@ class ModelRunner:
             info.coverage_len is not None and seq.seq_len > info.coverage_len
         )
         if not need_build:
-            prefill_works.append(
-                {"kind": "cached", "seq": seq, "embedding_info": info}
-            )
+            prefill_works.append({"kind": "cached", "seq": seq, "embedding_info": info})
             return
         ready_len = self._disagg_ready_len(st)
         # Gather the ready-prefix items in token-span order so the concatenated
@@ -1631,9 +1596,7 @@ class ModelRunner:
         placeholder_token_id_cpu = torch.tensor(
             self.model.get_mm_placeholder_token_ids(), device="cpu"
         )
-        is_multimodal_cpu = torch.isin(
-            input_ids_cpu, placeholder_token_id_cpu
-        )
+        is_multimodal_cpu = torch.isin(input_ids_cpu, placeholder_token_id_cpu)
         return input_ids_cpu, is_multimodal_cpu
 
     def _mm_precompute_hash(self, seq: GenerationSequence) -> None:
@@ -1663,15 +1626,14 @@ class ModelRunner:
             return
         if seq.mm_contents is None:
             return
-        if seq.hash_token_ids is not None or getattr(
-            seq, "_mm_precomputed", None
-        ) is not None:
+        if (
+            seq.hash_token_ids is not None
+            or getattr(seq, "_mm_precomputed", None) is not None
+        ):
             return  # already built (e.g. preemption + re-schedule).
 
         mm_input, image_grid_thw, video_grid_thw = self._mm_run_processor(seq)
-        input_ids_cpu, is_multimodal_cpu = self._mm_build_is_multimodal_cpu(
-            seq
-        )
+        input_ids_cpu, is_multimodal_cpu = self._mm_build_is_multimodal_cpu(seq)
         mm_bundle_key, item_hashes = self._build_mm_content_hashes(
             mm_input, image_grid_thw, video_grid_thw
         )
@@ -1752,7 +1714,11 @@ class ModelRunner:
         sglang's ``pad_input_tokens`` trick adapted to gllm's flat-page
         cache layout.
         """
-        mask = is_multimodal_cpu.tolist() if isinstance(is_multimodal_cpu, torch.Tensor) else list(is_multimodal_cpu)
+        mask = (
+            is_multimodal_cpu.tolist()
+            if isinstance(is_multimodal_cpu, torch.Tensor)
+            else list(is_multimodal_cpu)
+        )
         out = list(token_ids)
         n = len(out)
         i = 0
@@ -1824,9 +1790,7 @@ class ModelRunner:
                 # (one prompt's worth of ids) so a synchronous H2D is cheap
                 # and avoids the pageable-memory caveats of non_blocking.
                 input_ids = work["input_ids_cpu"].to(device, non_blocking=True)
-                is_multimodal = work["is_multimodal_cpu"].to(
-                    device, non_blocking=True
-                )
+                is_multimodal = work["is_multimodal_cpu"].to(device, non_blocking=True)
                 embed_result = self.model.embed_input_ids(
                     input_ids,
                     mm_embeddings,
@@ -1850,13 +1814,9 @@ class ModelRunner:
                     coverage_len=work.get("coverage_len"),
                 )
                 self.embedding_cache[seq.seq_id] = embedding_info
-                embedding = prompt_embeddings[
-                    seq.computed_token_num : seq.seq_len, :
-                ]
+                embedding = prompt_embeddings[seq.computed_token_num : seq.seq_len, :]
                 deepstack_chunk = (
-                    prompt_deepstack[
-                        :, seq.computed_token_num : seq.seq_len, :
-                    ]
+                    prompt_deepstack[:, seq.computed_token_num : seq.seq_len, :]
                     if prompt_deepstack is not None
                     else None
                 )
@@ -1933,9 +1893,7 @@ class ModelRunner:
             for chunk, emb in zip(batch_deepstack, batch_embeddings):
                 n = emb.shape[0]
                 if chunk is not None:
-                    self.model._set_deepstack_input_embeds(
-                        chunk, offset=offset
-                    )
+                    self.model._set_deepstack_input_embeds(chunk, offset=offset)
                 offset += n
 
         return torch.concat(batch_embeddings)
@@ -1953,7 +1911,9 @@ class ModelRunner:
             self.input_hidden_states[: hidden_states.shape[0]] = hidden_states
             self.input_data.embedding_size = hidden_states.shape[0]
 
-    def prepare_input(self, seqs: List[GenerationSequence] = None, input_data: InputData = None):
+    def prepare_input(
+        self, seqs: List[GenerationSequence] = None, input_data: InputData = None
+    ):
         if input_data is not None:
             self.input_data.set_input_from_prebuilt(input_data)
         else:
@@ -1991,12 +1951,9 @@ class ModelRunner:
     def _mtp_decide(self, num_decodes: int) -> bool:
         qlen = 1 + self._mtp_k
         fits_token_budget = (
-            qlen > 1
-            and num_decodes * qlen <= self.max_num_batched_tokens
+            qlen > 1 and num_decodes * qlen <= self.max_num_batched_tokens
         )
-        fits_perf_gate = (
-            self._mtp_max_batch <= 0 or num_decodes <= self._mtp_max_batch
-        )
+        fits_perf_gate = self._mtp_max_batch <= 0 or num_decodes <= self._mtp_max_batch
         # DP-attention replicas must agree on the whole multi-forward MTP
         # cadence and publish different row counts for bootstrap, each draft
         # step, and verify. That protocol is not wired yet; entering MTP with
@@ -2017,9 +1974,7 @@ class ModelRunner:
             return False
         return self._mtp_decide(num_decodes)
 
-    def _mtp_drop_relay(
-        self, seqs: Optional[List[GenerationSequence]] = None
-    ) -> None:
+    def _mtp_drop_relay(self, seqs: Optional[List[GenerationSequence]] = None) -> None:
         """Invalidate fused relay state after a plain decode advance.
 
         A plain decode step advances every seq by one token without refreshing
@@ -2050,9 +2005,7 @@ class ModelRunner:
         """
         relay = self._mtp_relay.pop(seq_id, None)
         if relay is None:
-            raise RuntimeError(
-                f"missing materialized MTP relay for sequence {seq_id}"
-            )
+            raise RuntimeError(f"missing materialized MTP relay for sequence {seq_id}")
         return int(relay[0])
 
     def mtp_prep_eligible(self, seqs: List[GenerationSequence]) -> bool:
@@ -2068,9 +2021,9 @@ class ModelRunner:
         if not (self.mtp_enabled and not is_dp_attn() and is_last_pp_rank()):
             return False
         if not seqs or not seqs[-1].computed_prompt:
-            return False   # prefill / mixed batch
+            return False  # prefill / mixed batch
         if not self.mtp_speculate_batch(len(seqs)):
-            return False   # batch too large to profit from speculation
+            return False  # batch too large to profit from speculation
         return True
 
     def prepare_input_mtp(self, seqs: List[GenerationSequence]) -> None:
@@ -2090,9 +2043,7 @@ class ModelRunner:
         idata.num_decode_tokens = len(seqs)
         idata.num_prefills = 0
         idata.max_query_len = 1
-        idata.install_forward_metadata_plan(
-            ForwardMetadataPlan.deferred_mtp(len(seqs))
-        )
+        idata.install_forward_metadata_plan(ForwardMetadataPlan.deferred_mtp(len(seqs)))
 
     def mtp_async_can_chain(self, seqs: List[GenerationSequence]) -> bool:
         """Whether ``seqs`` can consume the predecessor wholly on the GPU.
@@ -2131,7 +2082,9 @@ class ModelRunner:
         ``pad_for_cuda_graph`` already does for the decode-graph padding.
         """
         page = self.memory_manager.dummy_page if runtime else None
-        seqs = [GenerationSequence(idx, [1, 2], [], output_len=1) for idx in range(size)]
+        seqs = [
+            GenerationSequence(idx, [1, 2], [], output_len=1) for idx in range(size)
+        ]
         for seq in seqs:
             seq.page_table.append(seq.seq_id if page is None else page)
             seq.prompt_len = 1
@@ -2205,9 +2158,7 @@ class ModelRunner:
             self.input_data.set_mrope_position(
                 torch.zeros((3, num_cal_tokens), device="cpu")
             )
-        stream_ctx = (
-            torch.cuda.stream(stream) if stream is not None else _nullcontext()
-        )
+        stream_ctx = torch.cuda.stream(stream) if stream is not None else _nullcontext()
         with stream_ctx:
             self._prepare_attention_metadata(self.input_data)
             if is_first_pp_rank():
@@ -2248,15 +2199,17 @@ class ModelRunner:
         if stream is None:
             stream = getattr(self, "_cuda_graph_capture_stream", None)
             if stream is None:
-                stream = torch.cuda.Stream(
-                    device=torch.cuda.current_device()
-                )
+                stream = torch.cuda.Stream(device=torch.cuda.current_device())
                 self._cuda_graph_capture_stream = stream
 
         iterator = self.capture_sizes
         if get_local_rank() == 0:
-            logger.info(f"Capturing decode full CUDA graphs for bucket sizes: {list(reversed(self.capture_sizes))}")
-            iterator = tqdm(self.capture_sizes, desc="Capturing Decode Full Graphs", ncols=100)
+            logger.info(
+                f"Capturing decode full CUDA graphs for bucket sizes: {list(reversed(self.capture_sizes))}"
+            )
+            iterator = tqdm(
+                self.capture_sizes, desc="Capturing Decode Full Graphs", ncols=100
+            )
         memory_pool = torch.cuda.graph_pool_handle()
 
         # If the custom NVLink-P2P all-reduce is active, wrap the whole
@@ -2308,7 +2261,9 @@ class ModelRunner:
                     seqs = self.create_dummy_seqs(size)
                     self.input_data.cal_and_set_input(seqs=seqs)
                     if self.uses_mrope:
-                        self.input_data.set_mrope_position(torch.zeros((3, size), device="cpu"))
+                        self.input_data.set_mrope_position(
+                            torch.zeros((3, size), device="cpu")
+                        )
                     _set_dp_counts(size)
                     self.forward()
                 torch.cuda.synchronize()
@@ -2319,10 +2274,14 @@ class ModelRunner:
                     seqs = self.create_dummy_seqs(size)
                     self.input_data.cal_and_set_input(seqs=seqs)
                     if self.uses_mrope:
-                        self.input_data.set_mrope_position(torch.zeros((3, size), device="cpu"))
+                        self.input_data.set_mrope_position(
+                            torch.zeros((3, size), device="cpu")
+                        )
                     _set_dp_counts(size)
                     g = torch.cuda.CUDAGraph()
-                    with torch.cuda.graph(cuda_graph=g, pool=memory_pool, stream=stream):
+                    with torch.cuda.graph(
+                        cuda_graph=g, pool=memory_pool, stream=stream
+                    ):
                         self.forward()
                     self.size_to_graph[size] = g
                 # MTP: capture the draft-step graph per bucket on the same
@@ -2344,9 +2303,7 @@ class ModelRunner:
             torch.distributed.barrier(device_ids=[torch.cuda.current_device()])
 
     @torch.inference_mode()
-    def _capture_piecewise_graphs(
-        self, stream: Optional[torch.cuda.Stream]
-    ) -> None:
+    def _capture_piecewise_graphs(self, stream: Optional[torch.cuda.Stream]) -> None:
         """Capture every configured mixed-forward bucket during startup.
 
         Unlike decode, a piecewise graph's eager Attention/GDN breaks need real
@@ -2376,9 +2333,7 @@ class ModelRunner:
         # pool reuse and makes startup scale linearly with Python GC work.
         gc.collect()
         torch.cuda.empty_cache()
-        stream_ctx = (
-            torch.cuda.stream(stream) if stream is not None else _nullcontext()
-        )
+        stream_ctx = torch.cuda.stream(stream) if stream is not None else _nullcontext()
         with stream_ctx:
             for bucket in iterator:
                 seq_id = -(1_000_000 + bucket)
@@ -2386,9 +2341,7 @@ class ModelRunner:
                 seq.prompt_len = bucket
                 seq.computed_token_num = 0
                 seq.to_compute_token_num = bucket
-                self.memory_manager.pre_allocate_page(
-                    [seq], cacheable=False
-                )
+                self.memory_manager.pre_allocate_page([seq], cacheable=False)
                 self.memory_manager.allocate_ssm_slot(seq)
                 try:
                     # Dynamic Attention/SSM boundaries are not executed while
@@ -2494,9 +2447,7 @@ class ModelRunner:
                 raise RuntimeError("model forward has no ForwardMetadataPlan")
             plan.prepare_attention(backend, input_data)
 
-    def _piecewise_input_embeddings(
-        self, num_tokens: int
-    ) -> Optional[torch.Tensor]:
+    def _piecewise_input_embeddings(self, num_tokens: int) -> Optional[torch.Tensor]:
         """Return explicit model inputs for a piecewise forward.
 
         Piecewise capture starts immediately after token embedding so every
@@ -2720,9 +2671,9 @@ class ModelRunner:
         import time as _time
 
         if not hasattr(self, "_mtp_m_drafts"):
-            self._mtp_m_drafts = 0            # number of (seq,step) drafts
-            self._mtp_m_accepted = 0          # total accepted draft tokens
-            self._mtp_m_pos = [0] * k         # per-position accept counts
+            self._mtp_m_drafts = 0  # number of (seq,step) drafts
+            self._mtp_m_accepted = 0  # total accepted draft tokens
+            self._mtp_m_pos = [0] * k  # per-position accept counts
             self._mtp_m_t0 = _time.time()
         self._mtp_m_drafts += nd
         for na in n_accepted:
@@ -2764,7 +2715,8 @@ class ModelRunner:
                 logger.warning(
                     "MTP sparse top-k tie overflow on %d rows (margin=%d); "
                     "consider raising ModelRunner._SPARSE_TIE_MARGIN",
-                    n_of, self._SPARSE_TIE_MARGIN,
+                    n_of,
+                    self._SPARSE_TIE_MARGIN,
                 )
                 self._mtp_tie_overflow.zero_()
         self._mtp_sampling_seen = False
@@ -2789,7 +2741,9 @@ class ModelRunner:
             self._mtp_rng = torch.Generator(device=device)
         # A fixed base keeps runs reproducible; the counter advances in lockstep
         # across ranks. 0x9E3779B9 (golden-ratio) spreads consecutive seeds.
-        self._mtp_rng.manual_seed(0x9E3779B9 * (self._mtp_step + 1) & 0x7FFFFFFFFFFFFFFF)
+        self._mtp_rng.manual_seed(
+            0x9E3779B9 * (self._mtp_step + 1) & 0x7FFFFFFFFFFFFFFF
+        )
         self._mtp_step += 1
         return self._mtp_rng
 
@@ -2828,16 +2782,19 @@ class ModelRunner:
         dev = logits.device
         temps = torch.tensor(
             [s.temperature if s.temperature > 1e-5 else 1.0 for s in seqs],
-            device=dev, dtype=torch.float32,
+            device=dev,
+            dtype=torch.float32,
         ).unsqueeze(1)
         probs = torch.softmax(logits.float() / temps, dim=-1)
         top_ks = torch.tensor(
-            [s.top_k if s.top_k != -1 else self.memory_manager.vocab_size for s in seqs],
-            device=dev, dtype=torch.int32,
+            [
+                s.top_k if s.top_k != -1 else self.memory_manager.vocab_size
+                for s in seqs
+            ],
+            device=dev,
+            dtype=torch.int32,
         )
-        top_ps = torch.tensor(
-            [s.top_p for s in seqs], device=dev, dtype=torch.float32
-        )
+        top_ps = torch.tensor([s.top_p for s in seqs], device=dev, dtype=torch.float32)
         # Only renorm when some seq actually restricts (cheap guard).
         if int(top_ks.min().item()) < self.memory_manager.vocab_size:
             probs = top_k_renorm_prob(probs, top_ks)
@@ -2963,16 +2920,12 @@ class ModelRunner:
         0.16 ms at n=64, 1.01 -> 0.55 ms at n=256). Bit-identical to selecting on
         the widened logits -- the cast is lossless and order preserving.
         """
-        vals, idx = torch.topk(logits, k_pad, dim=-1)            # descending
+        vals, idx = torch.topk(logits, k_pad, dim=-1)  # descending
         vals = vals.float()
         # Tie-inclusive top-k: keep everything >= the top_k-th largest value.
-        kth = vals.gather(
-            1, (top_ks.long() - 1).clamp_(0, k_pad - 1).unsqueeze(1)
-        )
+        kth = vals.gather(1, (top_ks.long() - 1).clamp_(0, k_pad - 1).unsqueeze(1))
         keep = vals >= kth
-        probs = torch.softmax(
-            vals.masked_fill(~keep, float("-inf")) / temps, dim=-1
-        )
+        probs = torch.softmax(vals.masked_fill(~keep, float("-inf")) / temps, dim=-1)
         # top-p over the descending probs: keep the shortest prefix that reaches
         # ``top_p`` (exclusive cumsum < top_p), then renormalize.
         csum = probs.cumsum(dim=-1)
@@ -3038,9 +2991,7 @@ class ModelRunner:
             for i, s in enumerate(decode_seqs):
                 s.computed_token_num = len(orig_tokens[i]) + j
                 s.to_compute_token_num = 1
-                s.to_compute_tokens = [
-                    x1[i] if j == 0 else drafts_cols[i][-1]
-                ]
+                s.to_compute_tokens = [x1[i] if j == 0 else drafts_cols[i][-1]]
             self.prepare_input(decode_seqs)
             out_hidden = mtp.forward(self.input_data, cur_hidden, tok)
             logits = mtp.logits_from_hidden(out_hidden)
@@ -3062,7 +3013,8 @@ class ModelRunner:
                 q = self._mtp_probs_from_logits(logits, decode_seqs)  # [nd, vocab]
                 tok = (
                     torch.multinomial(q, num_samples=1, generator=gen)
-                    .squeeze(1).to(torch.int64)
+                    .squeeze(1)
+                    .to(torch.int64)
                 )
                 tok = self._mtp_bcast_tp(tok)
                 q_steps.append(q)
@@ -3094,9 +3046,7 @@ class ModelRunner:
             for i, s in enumerate(decode_seqs):
                 s.computed_token_num = len(orig_tokens[i]) + j
                 s.to_compute_token_num = 1
-                s.to_compute_tokens = [
-                    x1[i] if j == 0 else drafts_cols[i][-1]
-                ]
+                s.to_compute_tokens = [x1[i] if j == 0 else drafts_cols[i][-1]]
             self.prepare_input(decode_seqs)
             out_hidden = mtp.forward(self.input_data, cur_hidden, tok)
             tok = mtp.logits_from_hidden(out_hidden).argmax(dim=-1).to(torch.int64)
@@ -3193,7 +3143,7 @@ class ModelRunner:
 
         def _slot_for(pos):
             blk = block_table[row_idx, (pos // page_sz)]
-            return (blk.to(torch.int64) * page_sz + (pos % page_sz))
+            return blk.to(torch.int64) * page_sz + (pos % page_sz)
 
         for j in range(k):
             if j > 0:
@@ -3315,7 +3265,7 @@ class ModelRunner:
 
         def _slot_for(pos):
             blk = block_table[row_idx, (pos // page_sz)]
-            return (blk.to(torch.int64) * page_sz + (pos % page_sz))
+            return blk.to(torch.int64) * page_sz + (pos % page_sz)
 
         step_q, step_qv, step_qi, step_qd = [], [], [], []
         for j in range(k):
@@ -3354,12 +3304,12 @@ class ModelRunner:
         drafts_gpu = self._d_drafts[:nd, :k]
         if sparse:
             q = self._q_sparse(
-                torch.stack(step_qv, dim=1),           # [nd, k, k_pad]
+                torch.stack(step_qv, dim=1),  # [nd, k, k_pad]
                 torch.stack(step_qi, dim=1),
-                torch.stack(step_qd, dim=1),           # [nd, k]
+                torch.stack(step_qd, dim=1),  # [nd, k]
             )
         else:
-            q = self._q_dense(torch.stack(step_q, dim=1))   # [nd, k, vocab]
+            q = self._q_dense(torch.stack(step_q, dim=1))  # [nd, k, vocab]
         # Stash the GPU copy so the verify prep can take the tokens straight from
         # the device. The rejection accept still walks the drafts host-side (it
         # slices the committed prefix per seq), so materialize them here -- one
@@ -3385,9 +3335,7 @@ class ModelRunner:
         # the chain outputs and position helpers persistent so the hot path does
         # not allocate k clones, a stack output, a base-position clone, or a new
         # arange tensor on every speculative step.
-        self._d_drafts = torch.empty(
-            (B, self._mtp_k), dtype=torch.int64, device=dev
-        )
+        self._d_drafts = torch.empty((B, self._mtp_k), dtype=torch.int64, device=dev)
         self._d_base_pos = torch.empty(B, dtype=torch.long, device=dev)
         self._d_row_idx = torch.arange(B, dtype=torch.int64, device=dev)
         # Sampled-draft (rejection sampling) static buffers: per-seq sampling
@@ -3465,8 +3413,9 @@ class ModelRunner:
                 # the batch restricts top_k (the common serving case). Captured
                 # separately because ``k_pad`` is baked in; the dense graph above
                 # stays as the fallback for unrestricted-top_k batches.
-                self._d_topk[:bucket].fill_(self._sparse_kpad_capture
-                                            - self._SPARSE_TIE_MARGIN)
+                self._d_topk[:bucket].fill_(
+                    self._sparse_kpad_capture - self._SPARSE_TIE_MARGIN
+                )
                 self._draft_step_forward_sampled_sparse()
                 torch.cuda.synchronize()
                 gsp = torch.cuda.CUDAGraph()
@@ -3486,7 +3435,9 @@ class ModelRunner:
         nd = self._d_nd
         mtp = self.model.mtp
         self._prepare_attention_metadata(self._draft_input)
-        out_hidden = mtp.forward(self._draft_input, self._d_hidden[:nd], self._d_tok[:nd])
+        out_hidden = mtp.forward(
+            self._draft_input, self._d_hidden[:nd], self._d_tok[:nd]
+        )
         self._d_out_hidden[:nd].copy_(out_hidden)
         tok = mtp.logits_from_hidden(out_hidden).argmax(dim=-1).to(torch.int64)
         self._d_next_tok[:nd].copy_(tok)
@@ -3508,7 +3459,9 @@ class ModelRunner:
         nd = self._d_nd
         mtp = self.model.mtp
         self._prepare_attention_metadata(self._draft_input)
-        out_hidden = mtp.forward(self._draft_input, self._d_hidden[:nd], self._d_tok[:nd])
+        out_hidden = mtp.forward(
+            self._draft_input, self._d_hidden[:nd], self._d_tok[:nd]
+        )
         self._d_out_hidden[:nd].copy_(out_hidden)
         logits = mtp.logits_from_hidden(out_hidden)
         q = self._mtp_probs_static(
@@ -3534,7 +3487,9 @@ class ModelRunner:
         nd = self._d_nd
         mtp = self.model.mtp
         self._prepare_attention_metadata(self._draft_input)
-        out_hidden = mtp.forward(self._draft_input, self._d_hidden[:nd], self._d_tok[:nd])
+        out_hidden = mtp.forward(
+            self._draft_input, self._d_hidden[:nd], self._d_tok[:nd]
+        )
         self._d_out_hidden[:nd].copy_(out_hidden)
         logits = mtp.logits_from_hidden(out_hidden)
         qv, qi = self._mtp_sparse_probs(
@@ -3912,9 +3867,7 @@ class ModelRunner:
             mrope_deltas=self._mtp_mrope_deltas(decode_seqs),
             ctx_lens_gpu=(async_state.context_lens if async_state else None),
             x1_gpu=(async_state.relay_tokens if async_state else None),
-            num_accepted_gpu=(
-                async_state.resume_num_accepted if async_state else None
-            ),
+            num_accepted_gpu=(async_state.resume_num_accepted if async_state else None),
         )
         return gp
 
@@ -4022,9 +3975,8 @@ class ModelRunner:
         # snapshot paths keep reading column 0. Pure-attention models (DeepSeek
         # MTP) have no SSM segment and skip this.
         _ssm_seg = getattr(self.memory_manager, "ssm_segment", None)
-        _has_gdn = (
-            _ssm_seg is not None
-            and all(s.ssm_block_table is not None for s in decode_seqs)
+        _has_gdn = _ssm_seg is not None and all(
+            s.ssm_block_table is not None for s in decode_seqs
         )
         # A target bonus is not a verify INPUT, so it has no KV/GDN state yet.
         # Its draft seed, however, is the target hidden at the accepted verify
@@ -4137,8 +4089,7 @@ class ModelRunner:
         # verify graph, so serving never replays once per candidate.
         if (
             not extra_prefill_seqs
-            and
-            self._mtp_verify_graph
+            and self._mtp_verify_graph
             and self._verify_size_to_graph
             and nd <= max(self._verify_size_to_graph.keys())
         ):
@@ -4169,13 +4120,13 @@ class ModelRunner:
             else:
                 drafts = self._drafts_host(drafts, nd, kk)
             for i, s in enumerate(decode_seqs):
-                s.computed_token_num = len(orig_tokens[i])          # context cached
+                s.computed_token_num = len(orig_tokens[i])  # context cached
                 s.to_compute_token_num = 1 + kk
                 # InputData consumes this compact suffix directly. Keeping the
                 # committed token_ids list untouched removes an O(context)
                 # Python list copy from every mixed verify forward.
                 s.to_compute_tokens = [x1[i]] + drafts[i]
-                s._mtp_verify = True   # force the prefill-with-context attn path
+                s._mtp_verify = True  # force the prefill-with-context attn path
             self.memory_manager.pre_allocate_page(decode_seqs, cacheable=False)
             verify_and_prefill = list(decode_seqs) + extra_prefill_seqs
             self.prepare_input(verify_and_prefill)
@@ -4217,18 +4168,14 @@ class ModelRunner:
                 )
                 self._fixup_vl_decode_embeddings(num_decode_tokens)
                 mixed_embeddings = self.input_hidden_states[:total_mixed_tokens]
-                with torch.profiler.record_function(
-                    "gllm::mtp_target_mixed_piecewise"
-                ):
+                with torch.profiler.record_function("gllm::mtp_target_mixed_piecewise"):
                     all_hidden = self._piecewise_runner.run(
                         self.input_data, mixed_embeddings
                     )
             if all_hidden is None:
                 # Go through the normal runner wrapper: it prepares attention
                 # metadata and supplies Qwen-VL-compatible input embeddings.
-                with torch.profiler.record_function(
-                    "gllm::mtp_target_mixed_eager"
-                ):
+                with torch.profiler.record_function("gllm::mtp_target_mixed_eager"):
                     self.forward()
                 all_hidden = self.output_hidden_states[:total_mixed_tokens]
             # Verify seqs are uniform ``1+kk`` query length, so ``qsl`` is the
@@ -4245,9 +4192,7 @@ class ModelRunner:
                 num_extra = len(extra_prefill_seqs)
                 last_rows_gpu = self._mtp_mixed_last_rows[:num_extra]
                 last_rows_gpu.copy_(
-                    self.input_data.query_start_loc[
-                        nd + 1 : nd + num_extra + 1
-                    ]
+                    self.input_data.query_start_loc[nd + 1 : nd + num_extra + 1]
                 )
                 last_rows_gpu.sub_(1)
                 prefill_hidden = all_hidden.index_select(0, last_rows_gpu)
@@ -4280,8 +4225,7 @@ class ModelRunner:
                     completed = [
                         i
                         for i, s in enumerate(extra_prefill_seqs)
-                        if s.computed_token_num + s.to_compute_token_num
-                        >= s.prompt_len
+                        if s.computed_token_num + s.to_compute_token_num >= s.prompt_len
                     ]
                     if completed:
                         nc = len(completed)
@@ -4299,15 +4243,11 @@ class ModelRunner:
                             for i in completed
                         ]
                         completed_gpu.copy_(idx_host, non_blocking=True)
-                        new_state_context_lens.copy_(
-                            ctx_host, non_blocking=True
-                        )
+                        new_state_context_lens.copy_(ctx_host, non_blocking=True)
                         new_state_tokens = prefill_tokens_gpu.index_select(
                             0, completed_gpu
                         )
-                        new_state_hidden = prefill_hidden.index_select(
-                            0, completed_gpu
-                        )
+                        new_state_hidden = prefill_hidden.index_select(0, completed_gpu)
                 else:
                     prefill_tokens = prefill_tokens_gpu.cpu().tolist()
             else:
@@ -4320,8 +4260,8 @@ class ModelRunner:
         # [seq0: x1,d1..dk | seq1: ...]; the per-seq sampling params are expanded
         # on-device with ``repeat_interleave`` instead of building a 256-entry
         # python seq list per step.
-        p_dists = None          # dense [num_v, vocab] (unrestricted-top_k batches)
-        p_sparse = None         # (vals, idx) [nd, 1+kk, k_pad] (top_k-restricted)
+        p_dists = None  # dense [num_v, vocab] (unrestricted-top_k batches)
+        p_sparse = None  # (vals, idx) [nd, 1+kk, k_pad] (top_k-restricted)
         if _use_rej:
             num_v = nd * (1 + kk)
             temps, top_ks, top_ps = self._mtp_sample_params(decode_seqs, dev)
@@ -4335,9 +4275,7 @@ class ModelRunner:
                 # renorm passes over ``[nd*(1+k), vocab]`` (3.1 ms -> 0.6 ms at
                 # nd=64, and 254 MB of dense probs never materialized).
                 k_pad = self._mtp_kpad(decode_seqs)
-                pv, pi = self._mtp_sparse_probs(
-                    v_logits[:num_v], t_r, k_r, p_r, k_pad
-                )
+                pv, pi = self._mtp_sparse_probs(v_logits[:num_v], t_r, k_r, p_r, k_pad)
                 p_sparse = (pv.view(nd, rep, -1), pi.view(nd, rep, -1))
             else:
                 p_dists = self._mtp_probs_static(
@@ -4360,7 +4298,7 @@ class ModelRunner:
         # longer a reliable count here -- use ``nd`` directly. This batch is pure
         # decode/verify (no real non-decode seqs), so there is no tail to fill.
         results = [None] * nd
-        n_accepted = [0] * nd   # accepted DRAFT tokens per seq (excludes x1)
+        n_accepted = [0] * nd  # accepted DRAFT tokens per seq (excludes x1)
         new_relay = {}
 
         if _use_rej:
@@ -4386,7 +4324,7 @@ class ModelRunner:
             seq_ar = self._mtp_row_idx[:nd]
             sparse = p_sparse is not None
             if sparse:
-                p3_vals, p3_idx = p_sparse          # [nd, qlen, k_pad] each
+                p3_vals, p3_idx = p_sparse  # [nd, qlen, k_pad] each
             else:
                 p3 = p_dists.view(nd, qlen, p_dists.shape[-1])
             if kk > 0:
@@ -4401,21 +4339,22 @@ class ModelRunner:
                     # (pick its value) or outside it, where p is exactly 0 -- the
                     # same value the dense gather would return.
                     hit = (p3_idx[:, :kk] == idx).to(p3_vals.dtype)
-                    p_d = (p3_vals[:, :kk] * hit).sum(dim=-1)      # [nd,kk] p(d_p)
+                    p_d = (p3_vals[:, :kk] * hit).sum(dim=-1)  # [nd,kk] p(d_p)
                     # q(d_p) was recorded by the draft step that drew it.
                     q_d = q_dists.drawn
                 else:
-                    p_d = p3[:, :kk].gather(2, idx).squeeze(-1)    # [nd,kk] p(d_p)
+                    p_d = p3[:, :kk].gather(2, idx).squeeze(-1)  # [nd,kk] p(d_p)
                     q_d = q_dists.dense.gather(2, idx).squeeze(-1)  # [nd,kk] q(d_p)
                 # accept d_p with prob min(1, p/q); q<=0 can only happen for a
                 # token q never proposes, so treat it as certain acceptance
                 # (matches the old scalar branch).
                 ratio = torch.where(
-                    q_d > 0, (p_d / q_d.clamp_min(1e-30)).clamp_max(1.0),
+                    q_d > 0,
+                    (p_d / q_d.clamp_min(1e-30)).clamp_max(1.0),
                     torch.ones_like(p_d),
                 )
                 u = torch.rand((nd, kk), generator=gen, device=dev)
-                accept = u < ratio                                 # [nd,kk] bool
+                accept = u < ratio  # [nd,kk] bool
                 # Leading all-accept prefix length (same cumprod trick as greedy).
                 na_gpu = torch.cumprod(accept.to(torch.int32), dim=1).sum(dim=1)
             else:
@@ -4430,22 +4369,22 @@ class ModelRunner:
                 # ``(p-q)+`` is supported inside p's kept set (outside it p == 0,
                 # so the clamp is 0 there), which is why the residual only needs
                 # p's ``k_pad`` columns plus q's values at those same token ids.
-                p_row = p3_vals[seq_ar, na_l]                      # [nd, k_pad]
-                p_row_idx = p3_idx[seq_ar, na_l]                   # [nd, k_pad]
+                p_row = p3_vals[seq_ar, na_l]  # [nd, k_pad]
+                p_row_idx = p3_idx[seq_ar, na_l]  # [nd, k_pad]
             else:
-                p_row = p3[seq_ar, na_l]                           # [nd, V]
+                p_row = p3[seq_ar, na_l]  # [nd, V]
             if kk > 0:
                 sel = na_l.clamp(max=kk - 1)
                 if sparse:
                     # q's values at p's kept token ids. Everything outside q's own
                     # support is q == 0, so matching the two id lists (k_pad x
                     # k_pad per row, ~16k comparisons) is all that's needed.
-                    q_row_v = q_dists.vals[seq_ar, sel]            # [nd, k_pad]
-                    q_row_i = q_dists.idx[seq_ar, sel]             # [nd, k_pad]
-                    match = (q_row_i.unsqueeze(1) == p_row_idx.unsqueeze(2))
+                    q_row_v = q_dists.vals[seq_ar, sel]  # [nd, k_pad]
+                    q_row_i = q_dists.idx[seq_ar, sel]  # [nd, k_pad]
+                    match = q_row_i.unsqueeze(1) == p_row_idx.unsqueeze(2)
                     q_at_p = (match.to(q_row_v.dtype) * q_row_v.unsqueeze(1)).sum(-1)
                 else:
-                    q_at_p = q_dists.dense[seq_ar, sel]            # [nd, V]
+                    q_at_p = q_dists.dense[seq_ar, sel]  # [nd, V]
                 resid = torch.where(
                     (na_gpu < kk).unsqueeze(1),
                     (p_row - q_at_p).clamp_min(0),
@@ -4467,7 +4406,7 @@ class ModelRunner:
             rows = [na_gpu.to(torch.int64), bonus_gpu.to(torch.int64)]
             if d_gpu is not None:
                 rows.extend(d_gpu.t())
-            packed_cpu = torch.stack(rows).cpu()                   # [2+kk, nd]
+            packed_cpu = torch.stack(rows).cpu()  # [2+kk, nd]
             na_cpu = packed_cpu[0].tolist()
             bonus_cpu2 = packed_cpu[1].tolist()
             drafts_cpu = packed_cpu[2:].t().tolist() if d_gpu is not None else None
@@ -4498,7 +4437,9 @@ class ModelRunner:
                     for i in range(nd):
                         c = results[i]
                         lens[i] = len(c)
-                        grid[i, : len(c)] = torch.tensor(c, dtype=torch.int64, device=dev)
+                        grid[i, : len(c)] = torch.tensor(
+                            c, dtype=torch.int64, device=dev
+                        )
                         bonus_t[i] = new_relay[decode_seqs[i].seq_id][0]
                 src = get_rank() - get_tp_rank()
                 dist.broadcast(lens, src=src, group=get_ipc_tp_group())
@@ -4540,12 +4481,10 @@ class ModelRunner:
                     drafts_gpu = dg.to(vp.dtype)
                 else:
                     drafts_gpu = torch.tensor(drafts, device=dev, dtype=vp.dtype)
-                match = (vp[:, :kk] == drafts_gpu)                    # [nd,kk] bool
+                match = vp[:, :kk] == drafts_gpu  # [nd,kk] bool
                 # cumprod over the bool prefix: 1 until the first mismatch, 0 after
                 # -> sum = length of the leading all-accept prefix.
-                na_gpu = torch.cumprod(
-                    match.to(torch.int32), dim=1
-                ).sum(dim=1)  # [nd]
+                na_gpu = torch.cumprod(match.to(torch.int32), dim=1).sum(dim=1)  # [nd]
             else:
                 drafts_gpu = None
                 na_gpu = torch.zeros(nd, device=dev, dtype=torch.int32)
@@ -4587,18 +4526,14 @@ class ModelRunner:
                         drafts=(
                             drafts_gpu
                             if drafts_gpu is not None
-                            else torch.empty(
-                                (nd, 0), dtype=torch.int64, device=dev
-                            )
+                            else torch.empty((nd, 0), dtype=torch.int64, device=dev)
                         ),
                         num_accepted_drafts=na_gpu,
                         next_bonus=vp[seq_ar, na_l],
                         next_hidden=bonus_hidden_all,
                         producer_stream=torch.cuda.current_stream(),
                         extra_tokens=prefill_tokens_gpu,
-                        extra_seq_ids=tuple(
-                            s.seq_id for s in extra_prefill_seqs
-                        ),
+                        extra_seq_ids=tuple(s.seq_id for s in extra_prefill_seqs),
                         new_state_seq_ids=new_state_seq_ids,
                         new_state_context_lens=new_state_context_lens,
                         new_state_tokens=new_state_tokens,
@@ -4620,12 +4555,10 @@ class ModelRunner:
             rows.append(vp[seq_ar, na_gpu.to(torch.long)].to(torch.int64))
             if drafts_gpu is not None:
                 rows.extend(drafts_gpu.to(torch.int64).t())
-            packed_cpu = torch.stack(rows).cpu()   # [2+kk, nd]
+            packed_cpu = torch.stack(rows).cpu()  # [2+kk, nd]
             na_cpu = packed_cpu[0].tolist()
             bonus_cpu2 = packed_cpu[1].tolist()
-            drafts_cpu = (
-                packed_cpu[2:].t().tolist() if drafts_gpu is not None else None
-            )
+            drafts_cpu = packed_cpu[2:].t().tolist() if drafts_gpu is not None else None
             for i, s in enumerate(decode_seqs):
                 na = na_cpu[i]
                 n_accepted[i] = na
@@ -4682,8 +4615,7 @@ class ModelRunner:
         """
         seqs = self.input_data.seqs[: self.input_data.num_decodes]
         if any(
-            (s.temperature > 1e-5 and abs(s.temperature - 1.0) > 1e-5)
-            or s.top_k != 1
+            (s.temperature > 1e-5 and abs(s.temperature - 1.0) > 1e-5) or s.top_k != 1
             for s in seqs
         ):
             raise RuntimeError("async MTP currently requires greedy requests")
@@ -4737,9 +4669,7 @@ class ModelRunner:
         old_publish = self._mtp_async_publish
         self._mtp_async_publish = async_publish
         try:
-            result = self._mtp_decode(
-                hidden, x1, extra_prefill_seqs=prefill_seqs
-            )
+            result = self._mtp_decode(hidden, x1, extra_prefill_seqs=prefill_seqs)
         finally:
             self._mtp_async_publish = old_publish
         if async_publish and not isinstance(result, MtpAsyncCompletion):
@@ -4784,9 +4714,7 @@ class ModelRunner:
                 seq = by_id[seq_id]
                 if getattr(seq, "_overlap_freed", False):
                     continue
-                self._mtp_relay[seq.seq_id] = (
-                    int(relay_tokens[i]), relay_hidden[i]
-                )
+                self._mtp_relay[seq.seq_id] = (int(relay_tokens[i]), relay_hidden[i])
                 na = int(resume[i]) - 1
                 if seq.ssm_block_table is not None:
                     if na > 0:
@@ -4812,9 +4740,7 @@ class ModelRunner:
         # following pure-decode iteration can mistake the stale entry for a full
         # relay hit and seed its draft from the wrong sequence position.
         if self.input_data.num_prefills > 0 and self.input_data.num_decodes > 0:
-            self._mtp_drop_relay(
-                self.input_data.seqs[: self.input_data.num_decodes]
-            )
+            self._mtp_drop_relay(self.input_data.seqs[: self.input_data.num_decodes])
         # Fused MTP path. Full-relay batches go straight to draft/verify. Fresh
         # or relay-miss seqs are seeded by a verify-shaped padded bootstrap so
         # every MTP target forward keeps the same fixed qlen=1+k; the ordinary
@@ -4915,17 +4841,21 @@ class ModelRunner:
             # MTP speculative decoding: on a pure-decode batch, draft k tokens
             # per seq with the MTP head and verify them with one base forward,
             # committing the accepted prefix. Returns per-seq token LISTS.
-            if (self.mtp_enabled
-                    and self.input_data.num_prefills == 0
-                    and self.input_data.num_decodes > 0
-                    and not self.mtp_speculate_batch(self.input_data.num_decodes)):
+            if (
+                self.mtp_enabled
+                and self.input_data.num_prefills == 0
+                and self.input_data.num_decodes > 0
+                and not self.mtp_speculate_batch(self.input_data.num_decodes)
+            ):
                 # Batch too large to profit from speculation: this step already
                 # sampled one token per seq the plain way, which is the answer.
                 # The relay it leaves behind is stale (see ``_mtp_drop_relay``).
                 self._mtp_drop_relay()
-            elif (self.mtp_enabled
-                    and self.input_data.num_prefills == 0
-                    and self.input_data.num_decodes > 0):
+            elif (
+                self.mtp_enabled
+                and self.input_data.num_prefills == 0
+                and self.input_data.num_decodes > 0
+            ):
                 # x1 (this decode batch's first target token) was just sampled by
                 # the per-rank sampler above. Under GREEDY (top_k==1 -> argmax) it
                 # is TP-deterministic, but under SAMPLING each TP rank draws
@@ -5270,9 +5200,7 @@ class OverlapModelRunner(ModelRunner):
         with torch.cuda.stream(self.forward_stream):
             self.forward_stream.wait_event(self.overlap_runtime.input_ready_event)
             self.forward_stream.wait_stream(default_stream)
-            self.future_map.resolve_future(
-                self.input_data.tokens[:num_cal_tokens]
-            )
+            self.future_map.resolve_future(self.input_data.tokens[:num_cal_tokens])
 
             num_decode_tokens = sum(
                 s.to_compute_token_num
@@ -5360,9 +5288,7 @@ class OverlapModelRunner(ModelRunner):
                 # (``get_rank() - get_tp_rank()``), not the world's output rank
                 # 0 (which isn't even a member of group>0's TP subgroup).
                 tp_src = (
-                    get_rank() - get_tp_rank()
-                    if is_dp_attn()
-                    else get_output_rank()
+                    get_rank() - get_tp_rank() if is_dp_attn() else get_output_rank()
                 )
                 dist.broadcast(
                     next_tokens_gpu,
@@ -5394,12 +5320,12 @@ class OverlapModelRunner(ModelRunner):
                             sampled, non_blocking=True
                         )
                         if lp_k > 0:
-                            self._lp_topval_bufs[buf_idx][
-                                :batch_size, :lp_k
-                            ].copy_(top_vals, non_blocking=True)
-                            self._lp_topid_bufs[buf_idx][
-                                :batch_size, :lp_k
-                            ].copy_(top_ids, non_blocking=True)
+                            self._lp_topval_bufs[buf_idx][:batch_size, :lp_k].copy_(
+                                top_vals, non_blocking=True
+                            )
+                            self._lp_topid_bufs[buf_idx][:batch_size, :lp_k].copy_(
+                                top_ids, non_blocking=True
+                            )
 
             self.overlap_runtime.input_consumed_event.record(self.forward_stream)
 

--- a/gllm/tokenizers/__init__.py
+++ b/gllm/tokenizers/__init__.py
@@ -4,19 +4,22 @@
   (loaded from the checkpoint's ``encoding/`` dir; replaces a hand-written Jinja
   chat template).
 - :mod:`gllm.tokenizers.tool_parsers` -- model-native tool-call markup parsers
-  (Qwen / Kimi / DeepSeek) that turn generated text into structured
-  ``tool_calls``.
+  (Qwen / Kimi / DeepSeek) and OpenAI tool-call message normalization.
 """
 
-from gllm.tokenizers.deepseek_v32 import (
-    apply_dsv32_chat_template,
-    load_dsv32_encoder,
+from gllm.tokenizers.deepseek_v32 import apply_dsv32_chat_template, load_dsv32_encoder
+from gllm.tokenizers.tool_parsers import (
+    ToolParser,
+    get_tool_parser,
+    normalize_chat_template_messages,
+    normalize_chat_template_tool_arguments,
 )
-from gllm.tokenizers.tool_parsers import ToolParser, get_tool_parser
 
 __all__ = [
     "apply_dsv32_chat_template",
     "load_dsv32_encoder",
+    "normalize_chat_template_tool_arguments",
+    "normalize_chat_template_messages",
     "ToolParser",
     "get_tool_parser",
 ]

--- a/gllm/tokenizers/tool_parsers.py
+++ b/gllm/tokenizers/tool_parsers.py
@@ -37,6 +37,59 @@ from gllm.entrypoints.protocol import (
 )
 
 
+def normalize_chat_template_tool_arguments(messages) -> None:
+    """Convert OpenAI wire-format tool arguments for chat templates.
+
+    OpenAI assistant messages carry ``function.arguments`` as a JSON string,
+    while several Hugging Face chat templates (including Qwen3.5/3.8) iterate
+    the arguments as a mapping. Requests have already passed protocol
+    validation by this point, so decode valid JSON objects in place before
+    rendering. Invalid or non-object JSON is left untouched rather than
+    changing its meaning.
+    """
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        tool_calls = message.get("tool_calls")
+        if tool_calls is None or isinstance(tool_calls, (str, bytes, dict)):
+            continue
+        if not isinstance(tool_calls, list):
+            try:
+                tool_calls = list(tool_calls)
+            except TypeError:
+                continue
+            message["tool_calls"] = tool_calls
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                continue
+            function = tool_call.get("function")
+            if not isinstance(function, dict):
+                continue
+            arguments = function.get("arguments")
+            if not isinstance(arguments, str):
+                continue
+            try:
+                parsed = json.loads(arguments)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, dict):
+                function["arguments"] = parsed
+
+
+def normalize_chat_template_messages(messages) -> None:
+    """Normalize modern OpenAI messages for model-native chat templates.
+
+    ``developer`` is the current OpenAI instruction role, while many local
+    templates still only recognize the equivalent legacy ``system`` role.
+    Tool-call arguments also need conversion from their JSON wire string to the
+    mapping expected by several templates.
+    """
+    normalize_chat_template_tool_arguments(messages)
+    for message in messages:
+        if isinstance(message, dict) and message.get("role") == "developer":
+            message["role"] = "system"
+
+
 def _dump_arguments(arguments) -> str:
     """Tool-call arguments are always serialized as a JSON *string* in the
     OpenAI schema; pass through strings, JSON-encode everything else."""
@@ -60,12 +113,27 @@ def _dump_arguments(arguments) -> str:
 # Java/JS categories, where every value is a string).
 
 _TYPE_ALIASES: Dict[str, str] = {
-    "str": "string", "text": "string", "varchar": "string", "char": "string",
-    "enum": "string", "int": "integer", "int32": "integer", "int64": "integer",
-    "uint": "integer", "long": "integer", "short": "integer", "float": "number",
-    "float32": "number", "float64": "number", "double": "number",
-    "bool": "boolean", "dict": "object", "arr": "array", "list": "array",
-    "sequence": "array", "tuple": "array",
+    "str": "string",
+    "text": "string",
+    "varchar": "string",
+    "char": "string",
+    "enum": "string",
+    "int": "integer",
+    "int32": "integer",
+    "int64": "integer",
+    "uint": "integer",
+    "long": "integer",
+    "short": "integer",
+    "float": "number",
+    "float32": "number",
+    "float64": "number",
+    "double": "number",
+    "bool": "boolean",
+    "dict": "object",
+    "arr": "array",
+    "list": "array",
+    "sequence": "array",
+    "tuple": "array",
 }
 
 
@@ -124,11 +192,17 @@ def _coerce_to_schema_type(value: str, schema_types) -> Any:
     if isinstance(schema_types, str):
         schema_types = [schema_types]
     normalized = {
-        _TYPE_ALIASES.get(k, k)
-        for t in schema_types
-        for k in [str(t).strip().lower()]
+        _TYPE_ALIASES.get(k, k) for t in schema_types for k in [str(t).strip().lower()]
     }
-    for candidate in ("null", "integer", "number", "boolean", "object", "array", "string"):
+    for candidate in (
+        "null",
+        "integer",
+        "number",
+        "boolean",
+        "object",
+        "array",
+        "string",
+    ):
         if candidate not in normalized:
             continue
         if candidate == "null":
@@ -240,9 +314,7 @@ class ToolParser:
 
     name: str = "base"
 
-    def parse(
-        self, full_text: str, tools=None
-    ) -> Tuple[Optional[str], List[ToolCall]]:
+    def parse(self, full_text: str, tools=None) -> Tuple[Optional[str], List[ToolCall]]:
         raise NotImplementedError
 
     def stream_parser(self, tools=None) -> "StreamToolParser":
@@ -310,9 +382,7 @@ class QwenToolParser(ToolParser):
     def content_prefix(self, full_text: str) -> str:
         return full_text.split(self._START, 1)[0]
 
-    def parse(
-        self, full_text: str, tools=None
-    ) -> Tuple[Optional[str], List[ToolCall]]:
+    def parse(self, full_text: str, tools=None) -> Tuple[Optional[str], List[ToolCall]]:
         if self._START not in full_text:
             return full_text, []
 
@@ -388,9 +458,7 @@ class Qwen3ToolParser(ToolParser):
     def content_prefix(self, full_text: str) -> str:
         return full_text.split(self._START, 1)[0]
 
-    def parse(
-        self, full_text: str, tools=None
-    ) -> Tuple[Optional[str], List[ToolCall]]:
+    def parse(self, full_text: str, tools=None) -> Tuple[Optional[str], List[ToolCall]]:
         if self._START not in full_text:
             return full_text, []
 
@@ -412,9 +480,7 @@ class Qwen3ToolParser(ToolParser):
             args = _coerce_args(args, tools, name)
             tool_calls.append(
                 ToolCall(
-                    function=FunctionCall(
-                        name=name, arguments=_dump_arguments(args)
-                    )
+                    function=FunctionCall(name=name, arguments=_dump_arguments(args))
                 )
             )
 
@@ -451,9 +517,7 @@ class KimiToolParser(ToolParser):
             fid = fid[len("functions.") :]
         return fid
 
-    def parse(
-        self, full_text: str, tools=None
-    ) -> Tuple[Optional[str], List[ToolCall]]:
+    def parse(self, full_text: str, tools=None) -> Tuple[Optional[str], List[ToolCall]]:
         if self._SECTION_START not in full_text:
             return full_text, []
 
@@ -593,9 +657,7 @@ class DeepSeekToolParser(ToolParser):
             )
         return self.content_prefix(full_text).strip() or None, calls
 
-    def parse(
-        self, full_text: str, tools=None
-    ) -> Tuple[Optional[str], List[ToolCall]]:
+    def parse(self, full_text: str, tools=None) -> Tuple[Optional[str], List[ToolCall]]:
         if self._block_start(full_text) == -1:
             return full_text, []
 
@@ -625,7 +687,14 @@ def _qwen_parser_for_arch(architecture: Optional[str]) -> ToolParser:
 # Explicit ``--tool-call-parser`` names. The qwen-family names defer to the
 # architecture to pick the markup variant; "hermes"/"qwen3" force a variant.
 _AVAILABLE_NAMES = (
-    "qwen", "qwen2", "qwen2.5", "qwen3", "qwen3.5", "hermes", "kimi", "deepseek",
+    "qwen",
+    "qwen2",
+    "qwen2.5",
+    "qwen3",
+    "qwen3.5",
+    "hermes",
+    "kimi",
+    "deepseek",
 )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ tqdm
 transformers >= 5.11.0
 tiktoken >= 0.13.0 # Kimi K2.x tokenizer
 fastapi[standard] >= 0.115.0
-openai >= 1.99.1
+openai >= 2.53.0
 logger
 # Keep the CUDA build explicit: the unqualified aarch64 wheel on PyPI is CPU-only.
 # pyproject.toml routes uv's PyTorch resolution to the CUDA 13.0 wheel index.

--- a/tests/test_chat_template_tool_arguments.py
+++ b/tests/test_chat_template_tool_arguments.py
@@ -1,0 +1,87 @@
+from gllm.entrypoints.protocol import ChatCompletionRequest
+from gllm.tokenizers.tool_parsers import (
+    normalize_chat_template_messages,
+    normalize_chat_template_tool_arguments,
+)
+
+
+def test_openai_tool_argument_json_is_decoded_for_chat_templates():
+    messages = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "calculate",
+                        "arguments": '{"expression":"1+2"}',
+                    },
+                }
+            ],
+        }
+    ]
+
+    normalize_chat_template_tool_arguments(messages)
+
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == {
+        "expression": "1+2"
+    }
+
+
+def test_invalid_or_non_object_tool_arguments_are_unchanged():
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"function": {"name": "bad", "arguments": "{"}},
+                {"function": {"name": "list", "arguments": "[1, 2]"}},
+            ],
+        }
+    ]
+
+    normalize_chat_template_tool_arguments(messages)
+
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == "{"
+    assert messages[0]["tool_calls"][1]["function"]["arguments"] == "[1, 2]"
+
+
+def test_pydantic_tool_call_iterator_is_materialized_and_decoded():
+    request = ChatCompletionRequest.model_validate(
+        {
+            "model": "test",
+            "messages": [
+                {"role": "user", "content": "1+2"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "calculate",
+                                "arguments": '{"expression":"1+2"}',
+                            },
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "content": "3"},
+            ],
+        }
+    )
+
+    normalize_chat_template_tool_arguments(request.messages)
+
+    tool_calls = request.messages[1]["tool_calls"]
+    assert isinstance(tool_calls, list)
+    assert tool_calls[0]["function"]["arguments"] == {"expression": "1+2"}
+
+
+def test_developer_role_is_normalized_for_legacy_model_templates():
+    messages = [{"role": "developer", "content": "Be concise"}]
+
+    normalize_chat_template_messages(messages)
+
+    assert messages == [{"role": "system", "content": "Be concise"}]

--- a/tests/test_openai_protocol_compat.py
+++ b/tests/test_openai_protocol_compat.py
@@ -1,0 +1,341 @@
+import asyncio
+import base64
+import json
+from types import SimpleNamespace
+
+import pytest
+from openai.types.responses.response import Response
+from pydantic import TypeAdapter
+
+from gllm.entrypoints.protocol import ChatCompletionRequest, ResponseRequest
+from gllm.entrypoints.serving_chat import chat_completion_stream_generator
+from gllm.entrypoints.serving_responses import (
+    make_chat_request,
+    response_completion_generator,
+    response_input_to_messages,
+    response_stream_generator,
+)
+from gllm.tokenizers.tool_parsers import QwenToolParser
+from gllm.utils import StreamOutput
+
+
+class FakeStream:
+    def __init__(self, text="hello", texts=None):
+        self.items = [StreamOutput(part) for part in (texts or [text])]
+        self.iterated = False
+        self.seq = SimpleNamespace(
+            token_ids=[10, 11, 12],
+            raw_prompt_len=2,
+            ignore_eos=False,
+            finish_tokens=[99],
+            output_len=8,
+        )
+
+    async def __aiter__(self):
+        self.iterated = True
+        for item in self.items:
+            yield item
+
+
+def _collect(generator):
+    async def run():
+        return [item async for item in generator]
+
+    return asyncio.run(run())
+
+
+def test_current_chat_tool_and_json_schema_request_shapes_validate():
+    request = ChatCompletionRequest.model_validate(
+        {
+            "model": "test",
+            "messages": [{"role": "developer", "content": "Be concise"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "lookup",
+                        "parameters": {"type": "object"},
+                        "strict": True,
+                    },
+                }
+            ],
+            "tool_choice": "auto",
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "answer",
+                    "schema": {"type": "object"},
+                    "strict": True,
+                },
+            },
+        }
+    )
+    assert request.tools[0].function.strict is True
+    assert request.response_format.type == "json_schema"
+
+
+def test_legacy_functions_are_translated_to_tools():
+    request = ChatCompletionRequest.model_validate(
+        {
+            "model": "test",
+            "messages": [{"role": "user", "content": "hi"}],
+            "functions": [{"name": "ping"}],
+            "function_call": {"name": "ping"},
+        }
+    )
+    assert request.tools[0].function.name == "ping"
+    assert request.tool_choice.function.name == "ping"
+
+
+def test_chat_stream_has_stable_identity_role_and_separate_usage_chunk():
+    request = ChatCompletionRequest.model_validate(
+        {
+            "model": "test",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            "request_id": "request-1",
+        }
+    )
+    chunks = _collect(chat_completion_stream_generator(FakeStream(), request))
+    payloads = [json.loads(chunk.removeprefix("data: ")) for chunk in chunks[:-1]]
+    assert {payload["id"] for payload in payloads} == {"chatcmpl-request-1"}
+    assert payloads[0]["choices"][0]["delta"]["role"] == "assistant"
+    assert payloads[-2]["choices"][0]["finish_reason"] == "stop"
+    assert payloads[-1]["choices"] == []
+    assert payloads[-1]["usage"]["total_tokens"] == 3
+    assert chunks[-1] == "data: [DONE]\n\n"
+
+
+def test_responses_nonstream_and_stream_parse_with_current_sdk():
+    request = ResponseRequest.model_validate(
+        {"model": "test", "input": "hello", "instructions": "Be concise"}
+    )
+    chat_request = make_chat_request(request)
+    response = asyncio.run(
+        response_completion_generator(FakeStream(), request, chat_request)
+    )
+    parsed = Response.model_validate(response)
+    assert parsed.output_text == "hello"
+
+    events = _collect(response_stream_generator(FakeStream(), request, chat_request))
+    adapter = TypeAdapter(__import__("openai").types.responses.ResponseStreamEvent)
+    parsed_events = []
+    for raw in events:
+        data_line = next(line for line in raw.splitlines() if line.startswith("data: "))
+        parsed_events.append(adapter.validate_json(data_line.removeprefix("data: ")))
+    assert parsed_events[0].type == "response.created"
+    assert parsed_events[-1].type == "response.completed"
+
+
+def test_responses_stream_emits_before_generation_and_preserves_engine_deltas():
+    request = ResponseRequest.model_validate(
+        {"model": "test", "input": "hello", "stream": True}
+    )
+    chat_request = make_chat_request(request)
+    stream = FakeStream(texts=["he", "llo"])
+
+    async def run():
+        generator = response_stream_generator(stream, request, chat_request)
+        first = await generator.__anext__()
+        assert stream.iterated is False
+        return [first, *[event async for event in generator]]
+
+    events = asyncio.run(run())
+    payloads = [
+        json.loads(
+            next(line for line in raw.splitlines() if line.startswith("data: "))[
+                len("data: ") :
+            ]
+        )
+        for raw in events
+    ]
+    deltas = [
+        payload["delta"]
+        for payload in payloads
+        if payload["type"] == "response.output_text.delta"
+    ]
+    assert deltas == ["he", "llo"]
+    assert payloads[-1]["response"]["output"][0]["content"][0]["text"] == "hello"
+
+
+def test_responses_stream_translates_native_tool_markup_without_leaking_it():
+    request = ResponseRequest.model_validate(
+        {
+            "model": "test",
+            "input": "calculate 1+2",
+            "stream": True,
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "calculate",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"expression": {"type": "string"}},
+                    },
+                }
+            ],
+        }
+    )
+    chat_request = make_chat_request(request)
+    stream = FakeStream(
+        texts=[
+            "<tool_call>",
+            '{"name":"calculate","arguments":{"expression":"1+2"}}',
+            "</tool_call>",
+        ]
+    )
+    events = _collect(
+        response_stream_generator(
+            stream, request, chat_request, tool_parser=QwenToolParser()
+        )
+    )
+    payloads = [
+        json.loads(
+            next(line for line in raw.splitlines() if line.startswith("data: "))[
+                len("data: ") :
+            ]
+        )
+        for raw in events
+    ]
+    adapter = TypeAdapter(__import__("openai").types.responses.ResponseStreamEvent)
+    for payload in payloads:
+        adapter.validate_python(payload)
+    event_types = [payload["type"] for payload in payloads]
+    assert "response.output_text.delta" not in event_types
+    assert "response.function_call_arguments.delta" in event_types
+    function_call = payloads[-1]["response"]["output"][0]
+    assert function_call["type"] == "function_call"
+    assert function_call["name"] == "calculate"
+    assert json.loads(function_call["arguments"]) == {"expression": "1+2"}
+
+
+def test_stateless_response_tool_continuation_requires_original_user_input():
+    request = ResponseRequest.model_validate(
+        {
+            "model": "test",
+            "input": [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "20",
+                }
+            ],
+        }
+    )
+    with pytest.raises(ValueError, match="must include a user message"):
+        make_chat_request(request)
+
+
+def test_responses_input_image_uses_native_media_shape():
+    request = ResponseRequest.model_validate(
+        {
+            "model": "test",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "What is shown?"},
+                        {
+                            "type": "input_image",
+                            "image_url": "data:image/png;base64,AAAA",
+                            "detail": "auto",
+                        },
+                    ],
+                }
+            ],
+        }
+    )
+    messages = response_input_to_messages(request)
+    assert messages[0]["content"] == [
+        {"type": "text", "text": "What is shown?"},
+        {"type": "image", "image": "data:image/png;base64,AAAA"},
+    ]
+    assert all(part["type"] != "image_url" for part in messages[0]["content"])
+
+
+def test_responses_inline_text_file_is_added_to_prompt():
+    data = base64.b64encode("alpha,beta\n1,2\n".encode()).decode()
+    request = ResponseRequest.model_validate(
+        {
+            "model": "test",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_file",
+                            "filename": "values.csv",
+                            "file_data": data,
+                        },
+                        {"type": "input_text", "text": "Summarize it."},
+                    ],
+                }
+            ],
+        }
+    )
+    messages = response_input_to_messages(request)
+    assert isinstance(messages[0]["content"], str)
+    assert "[File: values.csv]" in messages[0]["content"]
+    assert "alpha,beta" in messages[0]["content"]
+    assert messages[0]["content"].endswith("Summarize it.")
+
+
+def test_responses_file_id_fails_explicitly_until_files_api_exists():
+    request = ResponseRequest.model_validate(
+        {
+            "model": "test",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_file", "file_id": "file_123"},
+                        {"type": "input_text", "text": "Summarize it."},
+                    ],
+                }
+            ],
+        }
+    )
+    with pytest.raises(ValueError, match="Files API"):
+        response_input_to_messages(request)
+
+
+def test_responses_pdf_is_explicitly_unsupported():
+    encoded = base64.b64encode(b"%PDF-1.7\n").decode()
+    request = ResponseRequest.model_validate(
+        {
+            "model": "test",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_file",
+                            "filename": "sample.pdf",
+                            "file_data": encoded,
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+    with pytest.raises(ValueError, match="PDF file inputs are not supported"):
+        response_input_to_messages(request)
+
+
+def test_responses_audio_stays_explicitly_unsupported():
+    request = ResponseRequest.model_validate(
+        {
+            "model": "test",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_audio", "input_audio": {"data": "AAAA"}}
+                    ],
+                }
+            ],
+        }
+    )
+    with pytest.raises(ValueError, match="Audio input is not supported"):
+        response_input_to_messages(request)


### PR DESCRIPTION
## Summary
- update OpenAI-compatible request/response schemas and error handling
- fix Qwen tool-call parsing and streaming protocol behavior
- add core Responses API support with function tools and true streaming
- add image and lightweight file inputs; audio, PDF, and file IDs remain explicitly unsupported

## Validation
- `pytest -q` (79 passed)
- pre-commit checks passed